### PR TITLE
Fix question support icon

### DIFF
--- a/client-fair-impact/components/assessment/question.tsx
+++ b/client-fair-impact/components/assessment/question.tsx
@@ -26,7 +26,7 @@ export default function Question<T extends FieldValues>({
           viewBox="0 0 24 24"
           strokeWidth={1.5}
           stroke="currentColor"
-          className="group-hover:text-fair_dark_blue-600 size-6 text-gray-600"
+          className="group-hover:text-fair_dark_blue-300 size-6 text-gray-600"
         >
           <path
             strokeLinecap="round"


### PR DESCRIPTION
Question support icon hover 'highlight' not clear enough, needs more contrasting color than the current dark blue. 
Made it into a lighter blue; `text-fair_dark_blue-300`. 
