### PR TITLE
Initial implementation of Glossaries in the API

### DIFF
--- a/api-fair-impact/src/app.module.ts
+++ b/api-fair-impact/src/app.module.ts
@@ -12,6 +12,7 @@ import { LanguagesModule } from './languages/languages.module';
 import { SeedingModule } from './seeding/seeding.module';
 import { validationSchema } from './config/validation-schema';
 import { AssessmentsModule } from './assessments/assessments.module';
+import { GlossariesModule } from './glossaries/glossaries.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { AssessmentsModule } from './assessments/assessments.module';
     LanguagesModule,
     SeedingModule,
     AssessmentsModule,
+    GlossariesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/api-fair-impact/src/content-language-modules/dto/create-content-language-module.dto.ts
+++ b/api-fair-impact/src/content-language-modules/dto/create-content-language-module.dto.ts
@@ -3,5 +3,10 @@ import { ContentLanguageModule } from '../entities/content-language-module.entit
 
 export class CreateContentLanguageModuleDto extends PickType(
   ContentLanguageModule,
-  ['language', 'digitalObjectType', 'digitalObjectTypeSchema', 'schema'] as const,
+  [
+    'language',
+    'digitalObjectType',
+    'digitalObjectTypeSchema',
+    'schema',
+  ] as const,
 ) {}

--- a/api-fair-impact/src/content-language-modules/entities/content-language-module.entity.ts
+++ b/api-fair-impact/src/content-language-modules/entities/content-language-module.entity.ts
@@ -1,9 +1,4 @@
-import {
-  IsNotEmpty,
-  IsObject,
-  IsString,
-  IsUUID,
-} from 'class-validator';
+import { IsNotEmpty, IsObject, IsString, IsUUID } from 'class-validator';
 import { DigitalObjectTypeSchema } from 'src/digital-object-type-schemas/entities/digital-object-type-schema.entity';
 import { DigitalObjectType } from 'src/digital-object-types/entities/digital-object-type.entity';
 import { Language } from 'src/languages/entities/language.entity';

--- a/api-fair-impact/src/digital-object-type-schemas/schemas/fair-schema.service.ts
+++ b/api-fair-impact/src/digital-object-type-schemas/schemas/fair-schema.service.ts
@@ -54,7 +54,7 @@ export class FAIRSchema implements SchemasService<FairAwareSchema> {
     const assessment = schemaStructure.assessment.map((principle) => {
       return {
         principle: null,
-        criteria: principle.criteria.map((criteria) => {
+        criteria: principle.criteria.map(() => {
           return {
             criteria: null,
             question: null,
@@ -113,7 +113,7 @@ export class FAIRSchema implements SchemasService<FairAwareSchema> {
       if (contentSchema.schemaType !== 'FAIR')
         throw new Error('Invalid schema type');
       // if (contentSchema.supportEmail !== schemaStructure.supportEmail)
-        // throw new Error('Invalid support email');
+      // throw new Error('Invalid support email');
 
       // We want to validate that language and languageCode are valid ISO 639-1 codes.
       // @TODO: Implement language validation.

--- a/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
+++ b/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
@@ -1,0 +1,6 @@
+import { GlossaryItem } from "../entities/glossary-item.entity";
+
+export class CreateGlossaryDto {
+    uuid: string;
+    items: GlossaryItem[];
+}

--- a/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
+++ b/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
@@ -1,6 +1,6 @@
+import { PickType } from "@nestjs/mapped-types";
 import { GlossaryItem } from "../entities/glossary-item.entity";
+import { Glossary } from "../entities/glossary.entity";
 
-export class CreateGlossaryDto {
-    uuid: string;
-    items: GlossaryItem[];
+export class CreateGlossaryDto extends PickType(Glossary, ["title", "items"]) {
 }

--- a/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
+++ b/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
@@ -1,6 +1,4 @@
-import { PickType } from "@nestjs/mapped-types";
-import { GlossaryItem } from "../entities/glossary-item.entity";
-import { Glossary } from "../entities/glossary.entity";
+import { PickType } from '@nestjs/mapped-types';
+import { Glossary } from '../entities/glossary.entity';
 
-export class CreateGlossaryDto extends PickType(Glossary, ["title", "items"]) {
-}
+export class CreateGlossaryDto extends PickType(Glossary, ['title', 'items']) {}

--- a/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsString } from "class-validator";
+import { Entity, ManyToOne } from "typeorm";
+import { Glossary } from "./glossary.entity";
+
+// note that the term with the glossary should be unique, but this is not enforced in the code
+@Entity()
+export class GlossaryItem {
+    @IsNotEmpty()
+    @IsString()
+    term: string;
+    
+    @IsNotEmpty()
+    @IsString()
+    definition: string;
+
+    @ManyToOne(() => Glossary, (glossary) => glossary.items)
+    glossary: Glossary;
+}

--- a/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
@@ -1,16 +1,22 @@
-import { IsNotEmpty, IsString } from "class-validator";
-import { Entity, ManyToOne } from "typeorm";
+import { IsNotEmpty, IsString, MaxLength } from "class-validator";
+import { Column, Entity, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 import { Glossary } from "./glossary.entity";
 
 // note that the term with the glossary should be unique, but this is not enforced in the code
 @Entity()
 export class GlossaryItem {
+    @PrimaryGeneratedColumn('uuid')
+    uuid: string
+
     @IsNotEmpty()
     @IsString()
+    @MaxLength(255) 
+    @Column()
     term: string;
-    
+
     @IsNotEmpty()
     @IsString()
+    @Column()
     definition: string;
 
     @ManyToOne(() => Glossary, (glossary) => glossary.items)

--- a/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
@@ -1,24 +1,27 @@
-import { IsNotEmpty, IsString, MaxLength } from "class-validator";
-import { Column, Entity, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
-import { Glossary } from "./glossary.entity";
+import { IsNotEmpty, IsString, IsUUID, MaxLength } from 'class-validator';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Glossary } from './glossary.entity';
 
 // note that the term with the glossary should be unique, but this is not enforced in the code
 @Entity()
 export class GlossaryItem {
-    @PrimaryGeneratedColumn('uuid')
-    uuid: string
+  @IsNotEmpty()
+  @IsString()
+  @IsUUID()
+  @PrimaryGeneratedColumn('uuid')
+  uuid: string;
 
-    @IsNotEmpty()
-    @IsString()
-    @MaxLength(255) 
-    @Column()
-    term: string;
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255)
+  @Column()
+  term: string;
 
-    @IsNotEmpty()
-    @IsString()
-    @Column()
-    definition: string;
+  @IsNotEmpty()
+  @IsString()
+  @Column()
+  definition: string;
 
-    @ManyToOne(() => Glossary, (glossary) => glossary.items)
-    glossary: Glossary;
+  @ManyToOne(() => Glossary, (glossary) => glossary.items)
+  glossary: Glossary;
 }

--- a/api-fair-impact/src/glossaries/entities/glossary.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary.entity.ts
@@ -8,11 +8,17 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-import { IsNotEmpty, IsString, IsUUID, MaxLength, ValidateNested } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsString,
+  IsUUID,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
 import { GlossaryItem } from './glossary-item.entity';
 import { Type } from 'class-transformer';
 
-// Note: we could make combination with the title unique; probably per language, 
+// Note: we could make combination with the title unique; probably per language,
 @Entity()
 export class Glossary {
   @IsNotEmpty()
@@ -29,7 +35,7 @@ export class Glossary {
 
   @DeleteDateColumn({ type: 'timestamptz' })
   deletedAt: Date;
-  
+
   @IsNotEmpty()
   @IsString()
   @MaxLength(255) // Note: arbitrary limit, but we should limit strings to reasonable values
@@ -37,7 +43,6 @@ export class Glossary {
   title: string;
 
   // Note: probably have a glossary per language, but that might be handled via the CLM later on
-
 
   @Type(() => GlossaryItem)
   @ValidateNested({ each: true })

--- a/api-fair-impact/src/glossaries/entities/glossary.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary.entity.ts
@@ -1,0 +1,30 @@
+import {
+    Column,
+    CreateDateColumn,
+    DeleteDateColumn,
+    Entity,
+    OneToMany,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+  } from 'typeorm';
+
+import { IsNotEmpty, IsString, IsUUID, MaxLength, ValidateNested } from 'class-validator';
+import { GlossaryItem } from './glossary-item.entity';
+import { Type } from 'class-transformer';
+
+@Entity()
+export class Glossary {
+  @IsNotEmpty()
+  @IsString()
+  @IsUUID()
+  @PrimaryGeneratedColumn('uuid')
+  uuid: string;
+
+  // Note: probably have a glossary per language, but that might be handled via the CLM later on
+
+
+  @OneToMany(() => GlossaryItem, (item) => item.glossary)
+  @ValidateNested({ each: true })
+  @Type(() => GlossaryItem)
+  items: GlossaryItem[];
+}

--- a/api-fair-impact/src/glossaries/entities/glossary.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary.entity.ts
@@ -1,17 +1,18 @@
 import {
-    Column,
-    CreateDateColumn,
-    DeleteDateColumn,
-    Entity,
-    OneToMany,
-    PrimaryGeneratedColumn,
-    UpdateDateColumn,
-  } from 'typeorm';
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 import { IsNotEmpty, IsString, IsUUID, MaxLength, ValidateNested } from 'class-validator';
 import { GlossaryItem } from './glossary-item.entity';
 import { Type } from 'class-transformer';
 
+// Note: we could make combination with the title unique; probably per language, 
 @Entity()
 export class Glossary {
   @IsNotEmpty()
@@ -20,11 +21,26 @@ export class Glossary {
   @PrimaryGeneratedColumn('uuid')
   uuid: string;
 
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamptz' })
+  deletedAt: Date;
+  
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255) // Note: arbitrary limit, but we should limit strings to reasonable values
+  @Column()
+  title: string;
+
   // Note: probably have a glossary per language, but that might be handled via the CLM later on
 
 
-  @OneToMany(() => GlossaryItem, (item) => item.glossary)
-  @ValidateNested({ each: true })
   @Type(() => GlossaryItem)
+  @ValidateNested({ each: true })
+  @OneToMany(() => GlossaryItem, (item) => item.glossary, { cascade: true })
   items: GlossaryItem[];
 }

--- a/api-fair-impact/src/glossaries/glossaries.controller.ts
+++ b/api-fair-impact/src/glossaries/glossaries.controller.ts
@@ -22,6 +22,6 @@ export class GlossariesController {
 
     @Get(':uuid')
     findOne(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
-        return this.findOne(uuid);
+        return this.glossariesService.findOne(uuid);
     }
 }

--- a/api-fair-impact/src/glossaries/glossaries.controller.ts
+++ b/api-fair-impact/src/glossaries/glossaries.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Param, ParseUUIDPipe, Post } from "@nestjs/common";
+import { GlossariesService } from "./glossaries.service";
+import { CreateGlossaryDto } from "./dto/create-glossery.dto";
+
+@Controller('glossaries')
+export class GlossariesController {
+    constructor(
+    private readonly glossariesService: GlossariesService,
+    ) {}
+
+    @Post()
+    create(
+    @Body() createGlossaryDto: CreateGlossaryDto,   
+    ) {
+        return this.glossariesService.create(createGlossaryDto);
+    }
+
+    @Get()
+    findAll() {
+        return this.glossariesService.findAll();
+    }
+
+    @Get(':uuid')
+    findOne(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+        return this.findOne(uuid);
+    }
+}

--- a/api-fair-impact/src/glossaries/glossaries.controller.ts
+++ b/api-fair-impact/src/glossaries/glossaries.controller.ts
@@ -1,27 +1,30 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post } from "@nestjs/common";
-import { GlossariesService } from "./glossaries.service";
-import { CreateGlossaryDto } from "./dto/create-glossery.dto";
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import { GlossariesService } from './glossaries.service';
+import { CreateGlossaryDto } from './dto/create-glossery.dto';
 
 @Controller('glossaries')
 export class GlossariesController {
-    constructor(
-    private readonly glossariesService: GlossariesService,
-    ) {}
+  constructor(private readonly glossariesService: GlossariesService) {}
 
-    @Post()
-    create(
-    @Body() createGlossaryDto: CreateGlossaryDto,   
-    ) {
-        return this.glossariesService.create(createGlossaryDto);
-    }
+  @Post()
+  create(@Body() createGlossaryDto: CreateGlossaryDto) {
+    return this.glossariesService.create(createGlossaryDto);
+  }
 
-    @Get()
-    findAll() {
-        return this.glossariesService.findAll();
-    }
+  @Get()
+  findAll() {
+    return this.glossariesService.findAll();
+  }
 
-    @Get(':uuid')
-    findOne(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
-        return this.glossariesService.findOne(uuid);
-    }
+  @Get(':uuid')
+  findOne(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+    return this.glossariesService.findOne(uuid);
+  }
 }

--- a/api-fair-impact/src/glossaries/glossaries.module.ts
+++ b/api-fair-impact/src/glossaries/glossaries.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GlossariesService } from './glossaries.service';
+import { GlossariesController } from './glossaries.controller';
+import { Glossary } from './entities/glossary.entity';
+
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Glossary]),
+  ],
+  controllers: [GlossariesController],
+  providers: [GlossariesService],
+  exports: [GlossariesService],
+})
+export class GlossariesModule {}

--- a/api-fair-impact/src/glossaries/glossaries.module.ts
+++ b/api-fair-impact/src/glossaries/glossaries.module.ts
@@ -5,11 +5,8 @@ import { GlossariesController } from './glossaries.controller';
 import { Glossary } from './entities/glossary.entity';
 import { GlossaryItem } from './entities/glossary-item.entity';
 
-
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Glossary, GlossaryItem]),
-  ],
+  imports: [TypeOrmModule.forFeature([Glossary, GlossaryItem])],
   controllers: [GlossariesController],
   providers: [GlossariesService],
   exports: [GlossariesService],

--- a/api-fair-impact/src/glossaries/glossaries.module.ts
+++ b/api-fair-impact/src/glossaries/glossaries.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { GlossariesService } from './glossaries.service';
 import { GlossariesController } from './glossaries.controller';
 import { Glossary } from './entities/glossary.entity';
+import { GlossaryItem } from './entities/glossary-item.entity';
 
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Glossary]),
+    TypeOrmModule.forFeature([Glossary, GlossaryItem]),
   ],
   controllers: [GlossariesController],
   providers: [GlossariesService],

--- a/api-fair-impact/src/glossaries/glossaries.service.spec.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GlossariesService } from './glossaries.service';
+
+describe('GlossariesService', () => {
+  let service: GlossariesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GlossariesService],
+    }).compile();
+
+    service = module.get<GlossariesService>(
+        GlossariesService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api-fair-impact/src/glossaries/glossaries.service.spec.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.spec.ts
@@ -9,9 +9,7 @@ describe('GlossariesService', () => {
       providers: [GlossariesService],
     }).compile();
 
-    service = module.get<GlossariesService>(
-        GlossariesService,
-    );
+    service = module.get<GlossariesService>(GlossariesService);
   });
 
   it('should be defined', () => {

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
@@ -8,53 +13,52 @@ import { CreateGlossaryDto } from './dto/create-glossery.dto';
 
 @Injectable()
 export class GlossariesService {
-    private readonly logger = new Logger(GlossariesService.name, {
-        timestamp: true,
+  private readonly logger = new Logger(GlossariesService.name, {
+    timestamp: true,
+  });
+
+  constructor(
+    @InjectRepository(Glossary)
+    private readonly glossaryRepository: Repository<Glossary>,
+  ) {}
+
+  async create(createGlossaryDto: CreateGlossaryDto): Promise<Glossary> {
+    let glossary = this.glossaryRepository.create({
+      ...createGlossaryDto,
     });
 
-    constructor(
-        @InjectRepository(Glossary)
-        private readonly glossaryRepository: Repository<Glossary>
-    ) { }
-
-    async create(
-        createGlossaryDto: CreateGlossaryDto,
-    ): Promise<Glossary> {
-        let glossary = this.glossaryRepository.create({
-            ...createGlossaryDto,
-        });
-
-        try {
-            glossary = await this.glossaryRepository.save(glossary);
-        } catch (error) {
-            this.logger.error(error);
-            throw new InternalServerErrorException('Failed to create Glossary!');
-        }
-        return glossary;
+    try {
+      glossary = await this.glossaryRepository.save(glossary);
+    } catch (error) {
+      this.logger.error(error);
+      throw new InternalServerErrorException('Failed to create Glossary!');
     }
+    return glossary;
+  }
 
-    async findAll(): Promise<Glossary[]> {
-        try {
-            const glossaries = await this.glossaryRepository.find();
-            return glossaries;
-        } catch (error) {
-            this.logger.error(error);
-            throw new InternalServerErrorException('Failed to find Glossaries!');
-        }
+  async findAll(): Promise<Glossary[]> {
+    try {
+      const glossaries = await this.glossaryRepository.find();
+      return glossaries;
+    } catch (error) {
+      this.logger.error(error);
+      throw new InternalServerErrorException('Failed to find Glossaries!');
     }
+  }
 
-    async findOne(uuid: string): Promise<Glossary> {
-        try {
-            const glossary = await this.glossaryRepository.findOne({ where: { uuid }, relations: { items: true } });
-            if (!glossary) {
-                throw new NotFoundException(
-                    `Glossary with uuid ${uuid} not found!`,
-                );
-            }
-            return glossary;
-        } catch (error) {
-            this.logger.error(error);
-            throw new InternalServerErrorException('Failed to find Glossary!');
-        }
+  async findOne(uuid: string): Promise<Glossary> {
+    try {
+      const glossary = await this.glossaryRepository.findOne({
+        where: { uuid },
+        relations: { items: true },
+      });
+      if (!glossary) {
+        throw new NotFoundException(`Glossary with uuid ${uuid} not found!`);
+      }
+      return glossary;
+    } catch (error) {
+      this.logger.error(error);
+      throw new InternalServerErrorException('Failed to find Glossary!');
     }
+  }
 }

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { Glossary } from './entities/glossary.entity';
+
+@Injectable()
+export class GlossariesService {
+    private readonly logger = new Logger(GlossariesService.name, {
+        timestamp: true,
+    });
+
+    constructor(
+      @InjectRepository(Glossary)
+      private readonly glossaryRepository: Repository<Glossary>
+    ) {}
+
+    async create(
+        createGlossaryDto: Glossary,
+    ): Promise<Glossary> {
+        let glossary = this.glossaryRepository.create({
+            ...createGlossaryDto,
+        });
+
+        try {
+            glossary = await this.glossaryRepository.save(glossary);
+        } catch (error) {
+            this.logger.error(error);
+            throw new InternalServerErrorException('Failed to create Glossary!');
+        }
+        return glossary;
+    }
+
+    async findAll(): Promise<Glossary[]> {
+        try {
+            const glossaries = await this.glossaryRepository.find();
+            return glossaries;
+        } catch (error) {
+            this.logger.error(error);
+            throw new InternalServerErrorException('Failed to find Glossaries!');
+        }
+    }
+
+    async findOne(uuid: string): Promise<Glossary> {
+        try {
+            const glossary = await this.glossaryRepository.findOne({ where: { uuid } });
+            if (!glossary) {
+                throw new NotFoundException(
+                    `Glossary with uuid ${uuid} not found!`,
+                );
+            }
+            return glossary;
+        } catch (error) {
+            this.logger.error(error);   
+            throw new InternalServerErrorException('Failed to find Glossary!');
+        }
+    }
+
+    /*
+    private glossaries = [
+        { id: 1, term: 'API', definition: 'Application Programming Interface' },
+        { id: 2, term: 'HTTP', definition: 'Hypertext Transfer Protocol' },
+        // Add more glossary terms here
+    ];
+
+    getGlossary() {
+        return this.glossaries;
+    }
+
+    getGlossaryById(id: number) {
+        return this.glossaries.find(glossary => glossary.id === id);
+    }
+    */
+}

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { Glossary } from './entities/glossary.entity';
+import { CreateGlossaryDto } from './dto/create-glossery.dto';
 
 @Injectable()
 export class GlossariesService {
@@ -12,12 +13,12 @@ export class GlossariesService {
     });
 
     constructor(
-      @InjectRepository(Glossary)
-      private readonly glossaryRepository: Repository<Glossary>
-    ) {}
+        @InjectRepository(Glossary)
+        private readonly glossaryRepository: Repository<Glossary>
+    ) { }
 
     async create(
-        createGlossaryDto: Glossary,
+        createGlossaryDto: CreateGlossaryDto,
     ): Promise<Glossary> {
         let glossary = this.glossaryRepository.create({
             ...createGlossaryDto,
@@ -44,7 +45,7 @@ export class GlossariesService {
 
     async findOne(uuid: string): Promise<Glossary> {
         try {
-            const glossary = await this.glossaryRepository.findOne({ where: { uuid } });
+            const glossary = await this.glossaryRepository.findOne({ where: { uuid }, relations: { items: true } });
             if (!glossary) {
                 throw new NotFoundException(
                     `Glossary with uuid ${uuid} not found!`,
@@ -52,24 +53,8 @@ export class GlossariesService {
             }
             return glossary;
         } catch (error) {
-            this.logger.error(error);   
+            this.logger.error(error);
             throw new InternalServerErrorException('Failed to find Glossary!');
         }
     }
-
-    /*
-    private glossaries = [
-        { id: 1, term: 'API', definition: 'Application Programming Interface' },
-        { id: 2, term: 'HTTP', definition: 'Hypertext Transfer Protocol' },
-        // Add more glossary terms here
-    ];
-
-    getGlossary() {
-        return this.glossaries;
-    }
-
-    getGlossaryById(id: number) {
-        return this.glossaries.find(glossary => glossary.id === id);
-    }
-    */
 }

--- a/api-fair-impact/src/languages/entities/language.entity.ts
+++ b/api-fair-impact/src/languages/entities/language.entity.ts
@@ -1,7 +1,6 @@
 import { IsEnum, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { ContentLanguageModule } from 'src/content-language-modules/entities/content-language-module.entity';
 import { IsGlobalAlpha } from 'src/decorators/is-global-alpha';
-import { DigitalObjectTypeSchema } from 'src/digital-object-type-schemas/entities/digital-object-type-schema.entity';
 import {
   Entity,
   UpdateDateColumn,

--- a/api-fair-impact/src/seeding/seeding.module.ts
+++ b/api-fair-impact/src/seeding/seeding.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import databaseConfig from 'src/config/database.config';
 import { Language } from 'src/languages/entities/language.entity';
 import { DigitalObjectType } from 'src/digital-object-types/entities/digital-object-type.entity';
+import { Glossary } from 'src/glossaries/entities/glossary.entity';
 
 @Module({
   imports: [
@@ -11,7 +12,7 @@ import { DigitalObjectType } from 'src/digital-object-types/entities/digital-obj
       name: 'Seeding Connection',
       ...databaseConfig.asProvider(),
     }),
-    TypeOrmModule.forFeature([Language, DigitalObjectType]),
+    TypeOrmModule.forFeature([Language, DigitalObjectType, Glossary]),
   ],
   providers: [SeedingService],
 })

--- a/api-fair-impact/src/seeding/seeding.service.ts
+++ b/api-fair-impact/src/seeding/seeding.service.ts
@@ -9,6 +9,7 @@ import {
 } from 'src/digital-object-type-schemas/entities/digital-object-type-schema.entity';
 import { digitalObjectTypeSchemaDATA } from './seeds/digital-object-type-schema-data.seeds';
 import { ContentLanguageModule } from 'src/content-language-modules/entities/content-language-module.entity';
+import { Glossary } from 'src/glossaries/entities/glossary.entity';
 
 @Injectable()
 export class SeedingService {
@@ -21,6 +22,29 @@ export class SeedingService {
   async seed(): Promise<void> {
     try {
       this.logger.log('Starting seeding');
+
+      this.logger.verbose('Seeding Glossary');
+      // just bang it in for now, we're testing...
+      await this.entityManager.insert(Glossary, {
+        items: [
+          {
+            term: 'FAIR',
+            definition: 'Findable, Accessible, Interoperable, Reusable',
+          },
+          {
+            term: 'PID',
+            definition: 'Persistent Identifier',
+          },
+          {
+            term: 'Metadata',
+            definition: 'Data about data',
+          },
+          {
+            term: 'Controlled Vocabulary',
+            definition: 'A list of terms that are created for specific uses or contexts',
+          },
+        ],
+      });
 
       this.logger.verbose('Seeding languages');
       await this.entityManager.upsert(Language, languageSeeds, {

--- a/api-fair-impact/src/seeding/seeding.service.ts
+++ b/api-fair-impact/src/seeding/seeding.service.ts
@@ -7,7 +7,6 @@ import {
   DigitalObjectTypeSchema,
   SchemaTypeEnum,
 } from 'src/digital-object-type-schemas/entities/digital-object-type-schema.entity';
-import { digitalObjectTypeSchemaDATA } from './seeds/digital-object-type-schema-data.seeds';
 import { ContentLanguageModule } from 'src/content-language-modules/entities/content-language-module.entity';
 import { Glossary } from 'src/glossaries/entities/glossary.entity';
 
@@ -17,14 +16,14 @@ export class SeedingService {
     timestamp: true,
   });
 
-  constructor(private readonly entityManager: EntityManager) { }
+  constructor(private readonly entityManager: EntityManager) {}
 
   async seed(): Promise<void> {
     try {
       this.logger.log('Starting seeding');
 
       this.logger.verbose('Seeding Glossary');
-      // just bang it in for now, we're testing...
+      // TODO use more official glossary information
       await this.entityManager.save(Glossary, {
         title: 'Glossary',
         items: [
@@ -42,7 +41,8 @@ export class SeedingService {
           },
           {
             term: 'Controlled Vocabulary',
-            definition: 'A list of terms that are created for specific uses or contexts',
+            definition:
+              'A list of terms that are created for specific uses or contexts',
           },
         ],
       });

--- a/api-fair-impact/src/seeding/seeding.service.ts
+++ b/api-fair-impact/src/seeding/seeding.service.ts
@@ -17,7 +17,7 @@ export class SeedingService {
     timestamp: true,
   });
 
-  constructor(private readonly entityManager: EntityManager) {}
+  constructor(private readonly entityManager: EntityManager) { }
 
   async seed(): Promise<void> {
     try {
@@ -25,7 +25,8 @@ export class SeedingService {
 
       this.logger.verbose('Seeding Glossary');
       // just bang it in for now, we're testing...
-      await this.entityManager.insert(Glossary, {
+      await this.entityManager.save(Glossary, {
+        title: 'Glossary',
         items: [
           {
             term: 'FAIR',


### PR DESCRIPTION
How to test:
In dev mode: 
- Change the `.env` file
```
# Database Host
#DATABASE_HOST=postgres
DATABASE_HOST=localhost
```

 - Start postgres with docker
```
docker compose up postgres -d
```

- In the api dir, start in dev mode:
```
pnpm start:dev
```
Request for the glossaries (from seeding:
```
curl http://localhost:3001/glossaries | jq
```
Should give at least one (with a uuid)
request that one, for example: 
```
curl http://localhost:3001/glossaries/a4cd4828-6b0e-44a3-8652-f66a6defa821 | jq
```
Should also show all the terms of that glossary

Related issue:
https://drivenbydata.atlassian.net/browse/FR-2