### PR TITLE
Add display of glossaries in the client app

### DIFF
--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -15,70 +15,67 @@ export default function ClientPage({ uuid }: { uuid: string }) {
   }
 
   return (
-      <>
-          <div className="sticky top-0 z-10 -mt-14 border-b border-gray-300 bg-white pt-14 pb-8">
-              <Breadcrumbs />
-              <div className="flex flex-col items-center justify-between sm:flex-row">
-                  <div>
-                      <h1 className="mb-2 text-2xl font-bold text-gray-800">
-                          Glossary
-                      </h1>
-                      <p className="text-base text-gray-600">
-                          This is a glossary.
-                      </p>
-                  </div>
-              </div>
+    <>
+      <div className="sticky top-0 z-10 -mt-14 border-b border-gray-300 bg-white pt-14 pb-8">
+        <Breadcrumbs />
+        <div className="flex flex-col items-center justify-between sm:flex-row">
+          <div>
+            <h1 className="mb-2 text-2xl font-bold text-gray-800">Glossary</h1>
+            <p className="text-base text-gray-600">This is a glossary.</p>
           </div>
+        </div>
+      </div>
 
-          <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-              <div className="sm:col-span-3">
-                  <label className="block text-sm/6 font-medium text-gray-900">
-                      UUID
-                  </label>
-                  <div className="mt-2">
-                      <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
-                          {data.uuid}
-                      </p>
-                  </div>
-              </div>
-              <div className="sm:col-span-3">
-                  <label className="block text-sm/6 font-medium text-gray-900">
-                      Title
-                  </label>
-                  <div className="mt-2">
-                      <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
-                          {data.title}
-                      </p>
-                  </div>
-              </div>
+      <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+        <div className="sm:col-span-3">
+          <label className="block text-sm/6 font-medium text-gray-900">
+            UUID
+          </label>
+          <div className="mt-2">
+            <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+              {data.uuid}
+            </p>
           </div>
-          <h2 className="mt-8 border-t border-gray-500 pt-8 text-base/7 font-semibold text-gray-900">
-              Glossary items
-          </h2>
-          {data.items.map((item, index) => (
-              <div key={index} className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 border-t border-gray-300">
-                  <div className="sm:col-span-6">
-                      <label className="block text-sm/6 font-medium text-gray-900">
-
-                      </label>
-                      <div className="mt-2">
-                          <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
-                              {item.term}
-                          </p>
-                      </div>
-                  </div>
-                  <div className="sm:col-span-6">
-                      <label className="block text-sm/6 font-medium text-gray-900">
-                          Definition
-                      </label>
-                      <div className="mt-2">
-                          <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
-                              {item.definition}
-                          </p>
-                      </div>
-                  </div>
-              </div>
-          ))}
-      </>
+        </div>
+        <div className="sm:col-span-3">
+          <label className="block text-sm/6 font-medium text-gray-900">
+            Title
+          </label>
+          <div className="mt-2">
+            <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+              {data.title}
+            </p>
+          </div>
+        </div>
+      </div>
+      <h2 className="mt-8 border-t border-gray-500 pt-8 text-base/7 font-semibold text-gray-900">
+        Glossary items
+      </h2>
+      {data.items.map((item, index) => (
+        <div
+          key={index}
+          className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 border-t border-gray-300 sm:grid-cols-6"
+        >
+          <div className="sm:col-span-6">
+            <label className="block text-sm/6 font-medium text-gray-900"></label>
+            <div className="mt-2">
+              <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+                {item.term}
+              </p>
+            </div>
+          </div>
+          <div className="sm:col-span-6">
+            <label className="block text-sm/6 font-medium text-gray-900">
+              Definition
+            </label>
+            <div className="mt-2">
+              <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+                {item.definition}
+              </p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
   );
 }

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Breadcrumbs from "@/components/beardcrumbs";
+import useGlossary from "@/hooks/use-glossary";
+
+export default function ClientPage({ uuid }: { uuid: string }) {
+  const { data, isLoading, isError } = useGlossary(uuid);
+
+  if (isLoading) {
+    return <h1 className="text-2xl font-bold text-gray-800">Loading...</h1>;
+  }
+
+  if (isError || !data) {
+    return <h1 className="text-2xl font-bold text-gray-800">Error</h1>;
+  }
+
+  return (
+      <>
+          <div className="sticky top-0 z-10 -mt-14 border-b border-gray-300 bg-white pt-14 pb-8">
+              <Breadcrumbs />
+              <div className="flex flex-col items-center justify-between sm:flex-row">
+                  <div>
+                      <h1 className="mb-2 text-2xl font-bold text-gray-800">
+                          Glossary
+                      </h1>
+                      <p className="text-base text-gray-600">
+                          This is a glossary.
+                      </p>
+                  </div>
+              </div>
+          </div>
+
+          <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+              <div className="sm:col-span-3">
+                  <label className="block text-sm/6 font-medium text-gray-900">
+                      UUID
+                  </label>
+                  <div className="mt-2">
+                      <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+                          {data.uuid}
+                      </p>
+                  </div>
+              </div>
+              <div className="sm:col-span-3">
+                  <label className="block text-sm/6 font-medium text-gray-900">
+                      Title
+                  </label>
+                  <div className="mt-2">
+                      <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+                          {data.title}
+                      </p>
+                  </div>
+              </div>
+          </div>
+          <h2 className="mt-8 border-t border-gray-500 pt-8 text-base/7 font-semibold text-gray-900">
+              Glossary items
+          </h2>
+          {data.items.map((item, index) => (
+              <div key={index} className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 border-t border-gray-300">
+                  <div className="sm:col-span-6">
+                      <label className="block text-sm/6 font-medium text-gray-900">
+
+                      </label>
+                      <div className="mt-2">
+                          <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+                              {item.term}
+                          </p>
+                      </div>
+                  </div>
+                  <div className="sm:col-span-6">
+                      <label className="block text-sm/6 font-medium text-gray-900">
+                          Definition
+                      </label>
+                      <div className="mt-2">
+                          <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+                              {item.definition}
+                          </p>
+                      </div>
+                  </div>
+              </div>
+          ))}
+      </>
+  );
+}

--- a/client-fair-impact/app/cms/glossaries/[uuid]/page.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/page.tsx
@@ -1,0 +1,29 @@
+import "server-only";
+
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
+
+import { fetchGlossary } from "@/hooks/use-glossary";
+import GlossaryDetailClientPage from "./client";
+
+export default async function CLMDetailPage({
+  params,
+}: {
+  params: Promise<{ uuid: string }>;
+}) {
+  const { uuid } = await params;
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["glossary", uuid],
+    queryFn: () => fetchGlossary(uuid),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <GlossaryDetailClientPage uuid={uuid} />
+    </HydrationBoundary>
+  );
+}

--- a/client-fair-impact/app/cms/glossaries/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/client.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Table, { TableHeader, TableBody } from "@/components/cms/table";
+import TableCell from "@/components/cms/table-cell";
+import TableRow from "@/components/cms/table-row";
+import useGlossaries from "@/hooks/use-glossaries";
+import { TimestampzToDate } from "@/lib/timestampz-to-date";
+import Link from "next/link";
+
+export default function GlossariesClientPage() {
+  const { data, isLoading, isError } = useGlossaries();
+
+  const tableHeaders = [
+    //"DOT Code",
+    //"Language",
+    "Title",
+    "Modified At",
+    "Created At",
+    "",
+  ];
+
+  if (isLoading || isError || !data) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        {tableHeaders.map((header, i) => (
+          <TableCell key={i}>{header}</TableCell>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {data.map((glossary) => (
+          <TableRow key={glossary.uuid}>
+            <TableCell>
+              <span className="font-bold">{glossary.title}</span>
+            </TableCell>
+            {/* <TableCell>
+              <span className="font-bold">{clms.digitalObjectType.code}</span>
+            </TableCell>
+            <TableCell>
+              <span className="font-bold">{clms.language.englishLabel}</span>
+            </TableCell>
+            <TableCell>
+              <span className="font-bold">
+                {clms.digitalObjectTypeSchema.version}
+              </span>
+            </TableCell> */}
+            <TableCell>{TimestampzToDate(glossary.updatedAt)}</TableCell>
+            <TableCell>{TimestampzToDate(glossary.createdAt)}</TableCell>
+            <TableCell>
+              <Link
+                href={`/cms/glossaries/${glossary.uuid}`}
+                className="hover:text-fair_dark_blue-600"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="size-6"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+                  />
+                </svg>
+              </Link>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/client-fair-impact/app/cms/glossaries/page.tsx
+++ b/client-fair-impact/app/cms/glossaries/page.tsx
@@ -1,27 +1,27 @@
 import Breadcrumbs from "@/components/beardcrumbs";
 import { fetchGlossaries } from "@/hooks/use-glossaries";
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 import GlossariesClientPage from "./client";
 
 export default async function GlossariesPage() {
-    const queryClient = new QueryClient();
-    await queryClient.prefetchQuery({
-      queryKey: ["glossaries"],
-      queryFn: () => fetchGlossaries(),
-    });
-    return (
-        <>
-            <Breadcrumbs />
-            <h1 className="mb-2 text-2xl font-bold text-gray-800">
-                Glossaries
-            </h1>
-            <p className="text-base text-gray-600">
-                ....
-            </p>
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["glossaries"],
+    queryFn: () => fetchGlossaries(),
+  });
+  return (
+    <>
+      <Breadcrumbs />
+      <h1 className="mb-2 text-2xl font-bold text-gray-800">Glossaries</h1>
+      <p className="text-base text-gray-600">....</p>
 
-            <HydrationBoundary state={dehydrate(queryClient)}>
-                <GlossariesClientPage />
-            </HydrationBoundary>
-        </>
-    );
-}   
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <GlossariesClientPage />
+      </HydrationBoundary>
+    </>
+  );
+}

--- a/client-fair-impact/app/cms/glossaries/page.tsx
+++ b/client-fair-impact/app/cms/glossaries/page.tsx
@@ -1,0 +1,27 @@
+import Breadcrumbs from "@/components/beardcrumbs";
+import { fetchGlossaries } from "@/hooks/use-glossaries";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import GlossariesClientPage from "./client";
+
+export default async function GlossariesPage() {
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery({
+      queryKey: ["glossaries"],
+      queryFn: () => fetchGlossaries(),
+    });
+    return (
+        <>
+            <Breadcrumbs />
+            <h1 className="mb-2 text-2xl font-bold text-gray-800">
+                Glossaries
+            </h1>
+            <p className="text-base text-gray-600">
+                ....
+            </p>
+
+            <HydrationBoundary state={dehydrate(queryClient)}>
+                <GlossariesClientPage />
+            </HydrationBoundary>
+        </>
+    );
+}   

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -1,9 +1,9 @@
-import Footer from '@/components/footer/footer';
-import Header from '@/components/header/header';
-import { fetchGlossary } from '@/hooks/use-glossary';
-import { IGlossaries, IGlossary } from '@/types/entities/glossary.interface';
-import React from 'react';
-
+import Footer from "@/components/footer/footer";
+import Header from "@/components/header/header";
+import { fetchGlossaries } from "@/hooks/use-glossaries";
+import { fetchGlossary } from "@/hooks/use-glossary";
+import { IGlossaries, IGlossary } from "@/types/entities/glossary.interface";
+import React from "react";
 
 export default async function GlossaryPage() {
   // const queryClient = new QueryClient();
@@ -13,10 +13,12 @@ export default async function GlossaryPage() {
   // });
 
   // use fetchGlossaries hook, just get them all for now
-  const glossaries: IGlossaries[] = await fetchGlossaries();   
-  // take the last glossary, 
+  const glossaries: IGlossaries[] = await fetchGlossaries();
+  // take the last glossary,
   // but we should get the one matching the selected DOT and language at some point
-  const glossary: IGlossary = await fetchGlossary(glossaries[glossaries.length - 1].uuid);
+  const glossary: IGlossary = await fetchGlossary(
+    glossaries[glossaries.length - 1].uuid,
+  );
 
   return (
     <>
@@ -24,26 +26,33 @@ export default async function GlossaryPage() {
       <main className="mx-auto max-w-7xl px-2 lg:px-8">
         {/* <h1>Glossary</h1> */}
         {glossary && (
-            <h1 className="text-3xl font-bold text-gray-700" style={{ textTransform: 'uppercase' }}>{glossary.title}</h1>
+          <h1
+            className="text-3xl font-bold text-gray-700"
+            style={{ textTransform: "uppercase" }}
+          >
+            {glossary.title}
+          </h1>
         )}
         {glossary && (
           // display the terms
-          <div className="py-6" >
-          <ul style={{ listStyleType: 'none', padding: 0 }}>
-            { 
-              glossary.items.map((item, index) => (
+          <div className="py-6">
+            <ul style={{ listStyleType: "none", padding: 0 }}>
+              {glossary.items.map((item) => (
                 // add a id to each term; could use item.term.replace(/[^a-zA-Z0-9-_:.]/g, '_')
-                <li key={item.uuid} style={{ marginBottom: '20px' }} id={item.uuid}>
+                <li
+                  key={item.uuid}
+                  style={{ marginBottom: "20px" }}
+                  id={item.uuid}
+                >
                   <strong>{item.term}</strong>
                   <p>{item.definition}</p>
                 </li>
-              ))  
-            }
-          </ul>
+              ))}
+            </ul>
           </div>
-        )}  
+        )}
       </main>
       <Footer />
     </>
   );
-};
+}

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -1,0 +1,49 @@
+import Footer from '@/components/footer/footer';
+import Header from '@/components/header/header';
+import { fetchGlossary } from '@/hooks/use-glossary';
+import { IGlossaries, IGlossary } from '@/types/entities/glossary.interface';
+import React from 'react';
+
+
+export default async function GlossaryPage() {
+  // const queryClient = new QueryClient();
+  // await queryClient.prefetchQuery({
+  //   queryKey: ["glossaries"],
+  //   queryFn: () => fetchGlossaries(), // just get them all for now
+  // });
+
+  // use fetchGlossaries hook, just get them all for now
+  const glossaries: IGlossaries[] = await fetchGlossaries();   
+  // take the last glossary, 
+  // but we should get the one matching the selected DOT and language at some point
+  const glossary: IGlossary = await fetchGlossary(glossaries[glossaries.length - 1].uuid);
+
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-7xl px-2 lg:px-8">
+        {/* <h1>Glossary</h1> */}
+        {glossary && (
+            <h1 className="text-3xl font-bold text-gray-700" style={{ textTransform: 'uppercase' }}>{glossary.title}</h1>
+        )}
+        {glossary && (
+          // display the terms
+          <div className="py-6" >
+          <ul style={{ listStyleType: 'none', padding: 0 }}>
+            { 
+              glossary.items.map((item, index) => (
+                // add a id to each term; could use item.term.replace(/[^a-zA-Z0-9-_:.]/g, '_')
+                <li key={item.uuid} style={{ marginBottom: '20px' }} id={item.uuid}>
+                  <strong>{item.term}</strong>
+                  <p>{item.definition}</p>
+                </li>
+              ))  
+            }
+          </ul>
+          </div>
+        )}  
+      </main>
+      <Footer />
+    </>
+  );
+};

--- a/client-fair-impact/components/assessment/support-drawer-arcordion.tsx
+++ b/client-fair-impact/components/assessment/support-drawer-arcordion.tsx
@@ -20,7 +20,7 @@ export default function SupportDrawerAccordion({
             <span className="text-fair_dark_blue-600 text-lg/7 font-bold">
               {material.title}
             </span>
-            <span className="ml-6 flex h-7 items-center text-fair_dark_blue-600">
+            <span className="text-fair_dark_blue-600 ml-6 flex h-7 items-center">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"

--- a/client-fair-impact/components/assessment/support-drawer.tsx
+++ b/client-fair-impact/components/assessment/support-drawer.tsx
@@ -41,7 +41,7 @@ export default function SupportDrawer({
                       <button
                         type="button"
                         onClick={() => onClose()}
-                        className="relative rounded-md bg-white text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-fair_dark_blue-600 focus:ring-offset-2 focus:outline-hidden"
+                        className="focus:ring-fair_dark_blue-600 relative rounded-md bg-white text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
                       >
                         <span className="absolute -inset-2.5" />
                         <span className="sr-only">Close panel</span>

--- a/client-fair-impact/components/cms/desktop-navigation.tsx
+++ b/client-fair-impact/components/cms/desktop-navigation.tsx
@@ -13,7 +13,7 @@ export const navigation: CMSNavigationGroup[] = [
       { title: "DOTS's", href: "/cms/digital-object-type-schemas" },
       { title: "CLM's", href: "/cms/content-language-modules" },
       { title: "Assessments", href: "/cms/assessments" },
-      // { title: "Glossary", href: "#" },
+      { title: "Glossaries", href: "/cms/glossaries" },
     ],
   },
   {

--- a/client-fair-impact/components/form/lexical/toolbar-plugin.tsx
+++ b/client-fair-impact/components/form/lexical/toolbar-plugin.tsx
@@ -44,7 +44,7 @@ export default function ToolbarPlugin() {
       }),
       editor.registerCommand(
         SELECTION_CHANGE_COMMAND,
-        (_payload, _newEditor) => {
+        () => {
           $updateToolbar();
           return false;
         },

--- a/client-fair-impact/components/header/header.tsx
+++ b/client-fair-impact/components/header/header.tsx
@@ -10,7 +10,7 @@ import { NavigationItem } from "@/types/navigation-item";
  */
 const navigation: NavigationItem[] = [
   { label: "About", href: "#" },
-  { label: "Glossary", href: "#" },
+  { label: "Glossary", href: "glossary" },
   { label: "Documentation", href: "#" },
   { label: "Contact", href: "#" },
 ];

--- a/client-fair-impact/hooks/use-glossaries.tsx
+++ b/client-fair-impact/hooks/use-glossaries.tsx
@@ -1,0 +1,21 @@
+import { IGlossaries } from "@/types/entities/glossary.interface";
+import { useQuery } from "@tanstack/react-query";
+
+export const fetchGlossaries = async (): Promise<
+IGlossaries[]
+> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_HOST}/glossaries`,
+  );
+  if (!response.ok) {
+    throw new Error("Failed to retrieve glossaries");
+  }
+  return response.json();
+};
+
+export default function useGlossaries() {
+  return useQuery<IGlossaries[]>({
+    queryKey: ["glossaries"],
+    queryFn: () => fetchGlossaries(),
+  });
+}

--- a/client-fair-impact/hooks/use-glossary.tsx
+++ b/client-fair-impact/hooks/use-glossary.tsx
@@ -1,0 +1,21 @@
+import { IGlossary } from "@/types/entities/glossary.interface";
+import { useQuery } from "@tanstack/react-query";
+
+export const fetchGlossary = async (
+  uuid: string,
+): Promise<IGlossary> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_HOST}/glossaries/${uuid}`,
+  );
+  if (!response.ok) {
+    throw new Error("Failed to retrieve glossary");
+  }
+  return response.json();
+};
+
+export default function useGlossary(uuid: string) {
+  return useQuery<IGlossary>({
+    queryKey: ["glossary", uuid],
+    queryFn: () => fetchGlossary(uuid),
+  });
+}

--- a/client-fair-impact/types/entities/glossary.interface.ts
+++ b/client-fair-impact/types/entities/glossary.interface.ts
@@ -1,0 +1,19 @@
+export interface IGlossary {
+    uuid: string;
+
+    updatedAt: string;
+    createdAt: string;
+    deletedAt: string;
+
+    title: string;
+    items: IGlossaryItem[];
+  }
+
+  export interface IGlossaryItem {
+    uuid: string;
+    
+    term: string;
+    definition: string;
+  }
+
+  export type IGlossaries = Omit<IGlossary, "items">;


### PR DESCRIPTION
Adds pages to the `cms` for the gloossaries and a specific glossary. 
Also adds the page fro the Glossary menu item; this shows the last (added) glossary for now. 
Note that there is no create,editing or delete for the glossary, only create via the API is available. 