### PR TITLE
FR-2 Extend Glossary

### DIFF
--- a/api-fair-impact/src/digital-object-types/entities/digital-object-type.entity.ts
+++ b/api-fair-impact/src/digital-object-types/entities/digital-object-type.entity.ts
@@ -11,6 +11,7 @@ import { IsNotEmpty, IsString, IsUUID, MaxLength } from 'class-validator';
 import { IsGlobalAlpha } from 'src/decorators/is-global-alpha';
 import { ContentLanguageModule } from 'src/content-language-modules/entities/content-language-module.entity';
 import { DigitalObjectTypeSchema } from 'src/digital-object-type-schemas/entities/digital-object-type-schema.entity';
+import { Glossary } from 'src/glossaries/entities/glossary.entity';
 
 /**
  * Digital Object Type (DOT) represents things like datasets, software, etc.
@@ -67,4 +68,10 @@ export class DigitalObjectType {
     },
   )
   digitalObjectTypeSchemas: DigitalObjectTypeSchema[];
+
+  @OneToMany(() => Glossary, (glossary) => glossary.digitalObjectType, {
+    cascade: ['soft-remove'],
+    orphanedRowAction: 'soft-delete',
+  })
+  glossaries: Glossary[];
 }

--- a/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
+++ b/api-fair-impact/src/glossaries/dto/create-glossery.dto.ts
@@ -1,4 +1,11 @@
 import { PickType } from '@nestjs/mapped-types';
 import { Glossary } from '../entities/glossary.entity';
 
-export class CreateGlossaryDto extends PickType(Glossary, ['title', 'items']) {}
+export class CreateGlossaryDto extends PickType(Glossary, 
+    [
+    'title', 
+    'items',
+    'language',
+    'digitalObjectType'
+    ] as const,
+) {}

--- a/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
@@ -1,15 +1,21 @@
-import { IsNotEmpty, IsString, IsUUID, MaxLength } from 'class-validator';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { IsNotEmpty, IsOptional, IsString, IsUrl, IsUUID, MaxLength } from 'class-validator';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { Glossary } from './glossary.entity';
 
 // note that the term with the glossary should be unique, but this is not enforced in the code
 @Entity()
+@Unique(['id', 'glossary'])
 export class GlossaryItem {
   @IsNotEmpty()
   @IsString()
   @IsUUID()
   @PrimaryGeneratedColumn('uuid')
   uuid: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Column()
+  id: string;
 
   @IsNotEmpty()
   @IsString()
@@ -21,6 +27,18 @@ export class GlossaryItem {
   @IsString()
   @Column()
   definition: string;
+
+  @IsOptional()
+  @IsString()
+  @IsUrl()
+  @Column({ nullable: true }) 
+  sourceUrl: string | null;
+
+  @IsOptional() 
+  @IsString()
+  @MaxLength(255)
+  @Column({ nullable: true })
+  acronym: string | null; 
 
   @ManyToOne(() => Glossary, (glossary) => glossary.items)
   glossary: Glossary;

--- a/api-fair-impact/src/glossaries/entities/glossary.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary.entity.ts
@@ -3,6 +3,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
@@ -17,6 +18,8 @@ import {
 } from 'class-validator';
 import { GlossaryItem } from './glossary-item.entity';
 import { Type } from 'class-transformer';
+import { DigitalObjectType } from 'src/digital-object-types/entities/digital-object-type.entity';
+import { Language } from 'src/languages/entities/language.entity';
 
 // Note: we could make combination with the title unique; probably per language,
 @Entity()
@@ -48,4 +51,15 @@ export class Glossary {
   @ValidateNested({ each: true })
   @OneToMany(() => GlossaryItem, (item) => item.glossary, { cascade: true })
   items: GlossaryItem[];
+
+  @IsNotEmpty()
+  @ManyToOne(() => DigitalObjectType, (dot) => dot.glossaries, {
+    onDelete: 'CASCADE',
+  })
+  digitalObjectType: DigitalObjectType;
+
+  @ManyToOne(() => Language, (language) => language.glossaries, {
+    onDelete: 'CASCADE',
+  })
+  language: Language;
 }

--- a/api-fair-impact/src/glossaries/glossaries.controller.ts
+++ b/api-fair-impact/src/glossaries/glossaries.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { GlossariesService } from './glossaries.service';
 import { CreateGlossaryDto } from './dto/create-glossery.dto';
+import { ParseISO639Pipe } from 'src/pipes/iso-639.pipe';
 
 @Controller('glossaries')
 export class GlossariesController {
@@ -21,6 +22,17 @@ export class GlossariesController {
   @Get()
   findAll() {
     return this.glossariesService.findAll();
+  }
+
+  @Get('language/:language/dot/:dot')
+  findByLanguageAndDot(
+    @Param('language', new ParseISO639Pipe()) language: string,
+    @Param('dot') dot: string,
+  ) {
+    return this.glossariesService.findByLanguageAndDot(
+      language,
+      dot,
+    );
   }
 
   @Get(':uuid')

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -38,7 +38,28 @@ export class GlossariesService {
 
   async findAll(): Promise<Glossary[]> {
     try {
-      const glossaries = await this.glossaryRepository.find();
+      const glossaries = await this.glossaryRepository.find({
+        select: {
+          uuid: true,
+          title: true,
+          updatedAt: true,
+          createdAt: true,
+          deletedAt: true,
+          digitalObjectType: {
+            uuid: true,
+            code: true,
+            label: true,
+          },
+          language: {
+            code: true,
+            englishLabel: true,
+          },
+        },
+        relations: { 
+          digitalObjectType: true,
+          language: true,
+        },
+      });
       return glossaries;
     } catch (error) {
       this.logger.error(error);
@@ -50,7 +71,11 @@ export class GlossariesService {
     try {
       const glossary = await this.glossaryRepository.findOne({
         where: { uuid },
-        relations: { items: true },
+        relations: { 
+          digitalObjectType: true,
+          language: true,
+          items: true, 
+        },
       });
       if (!glossary) {
         throw new NotFoundException(`Glossary with uuid ${uuid} not found!`);

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -67,6 +67,42 @@ export class GlossariesService {
     }
   }
 
+  async findByLanguageAndDot(
+    language: string,
+    digitalObjectTypeCode: string,
+  ): Promise<Glossary> {
+    try {
+      const glossary =
+        await this.glossaryRepository.findOne({
+          where: {
+            language: {
+              code: language,
+            },
+            digitalObjectType: {
+              code: digitalObjectTypeCode,
+            },
+          },
+        });
+
+      if (!glossary) {
+        throw new NotFoundException(
+          `Glossary with language ${language} and digital object type code ${digitalObjectTypeCode} not found!`,
+        );
+      }
+
+      return glossary;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
+      this.logger.error(error);
+      throw new InternalServerErrorException(
+        'Failed to fetch glossary!',
+      );
+    }
+  }
+
   async findOne(uuid: string): Promise<Glossary> {
     try {
       const glossary = await this.glossaryRepository.findOne({

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -82,6 +82,11 @@ export class GlossariesService {
               code: digitalObjectTypeCode,
             },
           },
+          relations: { 
+            digitalObjectType: true,
+            language: true,
+            items: true, 
+          },
         });
 
       if (!glossary) {

--- a/api-fair-impact/src/languages/entities/language.entity.ts
+++ b/api-fair-impact/src/languages/entities/language.entity.ts
@@ -1,6 +1,7 @@
 import { IsEnum, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { ContentLanguageModule } from 'src/content-language-modules/entities/content-language-module.entity';
 import { IsGlobalAlpha } from 'src/decorators/is-global-alpha';
+import { Glossary } from 'src/glossaries/entities/glossary.entity';
 import {
   Entity,
   UpdateDateColumn,
@@ -71,4 +72,11 @@ export class Language {
     orphanedRowAction: 'soft-delete',
   })
   contentLanguageModules: ContentLanguageModule[];
+
+
+  @OneToMany(() => Glossary, (glossary) => glossary.language, {
+    cascade: ['soft-remove'],
+    orphanedRowAction: 'soft-delete',
+  })
+  glossaries: Glossary[];
 }

--- a/api-fair-impact/src/seeding/seeding.service.ts
+++ b/api-fair-impact/src/seeding/seeding.service.ts
@@ -28,21 +28,35 @@ export class SeedingService {
         title: 'Glossary',
         items: [
           {
-            term: 'FAIR',
-            definition: 'Findable, Accessible, Interoperable, Reusable',
+            id: 'Access',
+            term: 'Access',
+            definition: `The continued, ongoing usability of a digital resource, retaining all qualities of authenticity,
+                accuracy and functionality deemed to be essential for the purposes the digital material was created
+                and/or acquired for. Users who have access can retrieve, manipulate, copy, and store copies on a
+                wide range of hard drives and external devices.`,
+            sourceUrl: 'https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource.html?uri=https://terms.codata.org/rdmt/access',
+            acronym: '',
           },
           {
-            term: 'PID',
-            definition: 'Persistent Identifier',
+            id: 'Consent',
+            term: 'Consent form',
+            definition: `According to the GDPR, the processing of personal data requires a legal basis. If consent is this basis,
+                this consent needs to be documented. Consent needs to be freely given, informed, unambiguous, specific
+                and by a clear affirmative action that signifies agreement to the processing of personal data.
+                The consent form is the document where participants indicate their decision of consent. The consent
+                form or the information letter accompanying the form should include information on the research and
+                consequences of participation, as well as information on how resulting data will be processed and shared.`,
+            sourceUrl: 'https:\/\/www.cessda.eu\/Training\/Training-Resources\/Library\/Data-Management-Expert-Guide\/5.-Protect\/Informed-consent',
+            acronym: '',
           },
           {
-            term: 'Metadata',
-            definition: 'Data about data',
-          },
-          {
+            id: 'CV',
             term: 'Controlled Vocabulary',
-            definition:
-              'A list of terms that are created for specific uses or contexts',
+            definition: `A controlled vocabulary is a flat, normalised, restricted list of terms for a specific use or context.
+                Thesauri and taxonomies are types of controlled vocabularies, but not all controlled vocabularies
+                are thesauri or taxonomies.`,
+            sourceUrl: 'https:\/\/doi.org\/10.5281\/zenodo.5362010',
+            acronym: 'CV',
           },
         ],
       });

--- a/api-fair-impact/src/seeding/seeding.service.ts
+++ b/api-fair-impact/src/seeding/seeding.service.ts
@@ -58,6 +58,263 @@ export class SeedingService {
             sourceUrl: 'https:\/\/doi.org\/10.5281\/zenodo.5362010',
             acronym: 'CV',
           },
+          {
+            id : "Dataset",
+            acronym : "" ,
+            term : "(Research) Data(set)" ,
+            definition : `Facts, measurements, recordings, records, or observations about the world collected by scientists and others,
+                  with a minimum of contextual interpretation.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata" ,    
+          },				
+          {
+            id : "Data availability statement",
+            acronym : "" ,
+            term : "Data availability statement" ,
+            definition : `A statement accompanying an article published in a scientific journal about the availability of the data
+                  underlying the article. What such a statement looks like is determined by each journal in their data sharing policy.
+                  The statement will usually describe where the data can be found and what access and reuse conditions there are.`,
+            sourceUrl : "https:\/\/libguides.wits.ac.za\/c.php?g=156853&p=6035295" ,
+          },			
+          {
+            id : "Data curation",
+            acronym : "" ,
+            term : "Data curation" ,
+            definition : `A managed process, throughout the data lifecycle, by which data & data collections are cleansed, documented,
+                  standardized, formatted and inter-related.`,
+            sourceUrl : "https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https://terms.codata.org/rdmt/data-curation" ,
+          },
+          {
+            id : "Data destruction",
+            acronym : "" ,
+            term : "Data destruction" ,
+            definition : `The process of destroying data stored on tapes, hard disks and other forms of electronic media so that it is
+                  completely unreadable and cannot be accessed or used.<\/p>
+              <p>In the context of digital data, “Data erasure” or “Data wiping” is the more accurate term. Data wiping is the
+                  process of irreversibly deleting or erasing all data beyond recovery without destruction.<\/p>`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-destruction" ,
+          },					
+          {
+            id : "DMP",
+            acronym : "DMP" ,
+            term : "Data management plan (DMP)" ,
+            definition : `A formal statement describing how research data will be managed and documented throughout a research project and
+                  the terms regarding the subsequent deposit of the data with a data repository for long-term management and preservation.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-management-plan" ,
+          },		
+          {
+            id : "Repository",
+            acronym : "" ,
+            term : "Data repository" ,
+            definition : `Repositories preserve, manage, and provide access to many types of digital materials in a variety of formats.
+                  Materials in online repositories are curated to enable search, discovery, and reuse`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Frepository" ,
+          },				
+          {
+            id : "Retention",
+            acronym : "" ,
+            term : "Data retention" ,
+            definition : `An organization’s established protocol for retaining information for operational or regulatory compliance needs.
+                  The objectives of a data retention policy are to keep important information for future use or reference,
+                  to organize information so it can be searched and accessed at a later date, and to dispose of information that is no longer needed.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-retention-policy/" ,
+          },
+          {
+            id : "stewardship",
+            acronym : "" ,
+            term : "Data stewardship" ,
+            definition : `Data stewardship is a shared responsibility between Principal Investigators and data stewards. Both roles have their
+                  own responsibilities and support roles related to all different parts of the research project.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-stewardship" ,
+          },
+          {
+            id : "Data type",
+            acronym : "" ,
+            term : "Data type" ,
+            definition : `Data type (or simply type) in computer science and computer programming is a classification identifying one of various
+                  types of data, that determines the possible values for that type; the operations that can be done on values of that type;
+                  the meaning of the data; and the way values of that type can be stored.<\/p>
+              <p>Common data types include: integers, booleans, characters, floating-point numbers, alphanumeric strings.`,
+            sourceUrl : "http:\/\/sedataglossary.shoutwiki.com\/wiki\/Data_type" ,
+          },
+          {
+            id : "Preservation",
+            acronym : "" ,
+            term : "Digital preservation" ,
+            definition : `The series of managed activities necessary to ensure continued access to digital materials for as long as necessary.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdigital-preservation" ,
+          },
+          {
+            id : "FAIR",
+            acronym : "FAIR" ,
+            term : "FAIR (Data Principles)" ,
+            definition : `A set of guiding principles to make data Findable, Accessible, Interoperable, and Reusable.
+              <ul>
+                  <li>Findable: (meta)data should be richly described to enable attribute-based search<\/li>
+                  <li>Accessible: (meta)data should be retrievable in a variety of formats that are sensible to humans and
+                      machines using persistent identifiers<\/li>
+                  <li>Interoperable: the description of (meta)data should follow community guidelines that use an open, well defined vocabulary<\\/li>
+                  <li>Reusable: the description of essential, recommended, and optional metadata elements should be machine processable
+                      and verifiable. Use should be easy and data should be citable to sustain data sharing and recognize the value of data<\/li>
+              <\/ul>
+              <p><a href=\"https:\/\/www.force11.org\/group\/fairgroup\/fairprinciples\"<\/a><\/p>`,
+            sourceUrl : "https:\/\/doi.org\/10.1038\/sdata.2016.18" ,
+          },
+          {
+            id : "File format",
+            acronym : "" ,
+            term : "File format" ,
+            definition : `The layout of a file in terms of how the data within the file are organized. A program that uses the data in a file
+                  must be able to recognize and possibly access data within the file. A particular file format is often indicated as
+                  part of a file’s name by a filename extension (suffix). Conventionally, the extension is separated by a period
+                  from the name and contains three or four letters that identify the format.<\/p>
+              <p>A proprietary file format is owned and copyrighted by a specific company. Open file formats are publicly available.</p>
+              <p><a href=\"http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-file-format\"<\/a><\/p>`,
+            sourceUrl : "https:\/\/www.cessda.eu\/Training\/Training-Resources\/Library\/Data-Management-Expert-Guide\/3.-Process\/File-formats-and-data-conversion" ,
+          },
+          {
+            id : "Harvesting",
+            acronym : "" ,
+            term : "Harvesting" ,
+            definition : `Metadata harvesting is an automated, regular process of collecting metadata descriptions from different sources to create
+                  useful aggregations, so that services can be built using metadata from many repositories.`,
+            sourceUrl : "http:\/\/sedataglossary.shoutwiki.com\/wiki\/Metadata_harvesting" ,
+          },
+          {
+            id : "Licence",
+            acronym : "" ,
+            term : "Licence" ,
+            definition : `A signed agreement to exploit a piece of IP such as a process, product, data, or software. An official document that gives
+                  you permission to own, do, or use something, usually after you have paid money and/or taken a test. Commonly used
+                  licences for open access works include Creative Commons licences. In the UK context, information about licences can be
+                  obtained from the IPO (Intellectual Property Office).`,
+            sourceUrl : "https://www.wikidata.org/wiki/Q79719" ,
+          },
+          {
+            id : "Link rot",
+            acronym : "" ,
+            term : "Link rot" ,
+            definition : `Link rot (also called link death, link breaking, or reference rot) is the disassociation between web addresses and their
+                  content. It’s the phenomenon of hyperlinks tending over time to cease to point to their originally targeted file, web page,
+                  or server due to that resource being relocated to a new address or becoming permanently unavailable.`,
+            sourceUrl : "https:\/\/dictionary.archivists.org\/entry\/link-rot.html" ,
+          },
+          {
+            id : "Long-term preservation",
+            acronym : "LTP" ,
+            term : "Long-term preservation" ,
+            definition : `Continued access to digital materials, or at least to the information contained in them, indefinitely.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Flong-term-preservation" ,
+          },
+          {
+            id : "Machine-actionable",
+            acronym : "" ,
+            term : "Machine-actionable" ,
+            definition : `A continuum of possible states wherein a digital object provides increasingly more detailed information to an
+                  autonomously-acting, computational data explorer. This information enables the agent—to a degree dependent on
+                  the amount of detail provided—to have the capacity, when faced with a digital object never encountered before, to:
+              <ol type=\"a\">
+                  <li>identify the type of object (with respect to both structure and intent), <\/li>
+                  <li>determine if it is useful within the context of the agent’s current task by interrogating metadata and/or data elements, <\/li>
+                  <li>determine if it is usable, with respect to license, consent, or other accessibility or use constraints, and <\/li>
+                  <li>take appropriate action, in much the same manner that a human would.<\/li>
+              <\/ol>`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmachine-actionable" ,
+          },
+          {
+            id : "Machine-readable",
+            acronym : "" ,
+            term : "Machine-readable format" ,
+            definition : `In a form that can be used and understood by a computer. A broad term encompassing: (a) digital surrogates created
+                  as a result of converting analogue materials to digital form (digitisation); (b) “born digital” for which there
+                  has never been and is never intended to be an analogue equivalent; and, (c) digital records.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmachine-readable" ,
+          },
+          {
+            id : "Metadata",
+            acronym : "" ,
+            term : "Metadata" ,
+            definition : `Data that defines and describes the characteristics of other data, used to improve both business and technical
+                  understanding of data and data-related processes.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmetadata" ,
+          },
+          {
+            id : "PID",
+            acronym : "PID" ,
+            term : "Persistent Identifier" ,
+            definition : `A persistent identifier is a long-lasting reference to a digital object that gives information about that object regardless
+                  of what happens to it. Developed to address “link rot,” a persistent identifier can be resolved to provide an appropriate
+                  representation of an object whether that object changes its online location or goes offline.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fpersistent-identifier" ,
+          },
+          {
+            id : "Preservation plan",
+            acronym : "" ,
+            term : "Preservation plan / policy" ,
+            definition : `A preservation plan outlines the principles steering the main activities regarding sustainable preservation of, as well as
+                  access to digital research data for, (re-)use within its user communities.`,
+            sourceUrl : "https:\/\/dans.knaw.nl\/en\/about\/strategy" ,
+          },
+          {
+            id : "Provenance",
+            acronym : "" ,
+            term : "Provenance" ,
+            definition : `A type of historical information or metadata about the origin, location or the source of something, or the history of
+                  the ownership or location of an object or resource including digital objects. For example, information about the
+                  Principal Investigator who recorded the data, and the information concerning its storage, handling, and migration`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fprovenance" ,
+          },
+          {
+            id : "SA",
+            acronym : "SA" ,
+            term : "Semantic artefact" ,
+            definition : `Semantic artefacts are machine readable models of knowledge such as controlled vocabularies, thesauri, and ontologies
+                  which facilitate the extraction and representation of knowledge within data sets using annotations or assertions.`,
+            sourceUrl : "https:\/\/www.fairsfair.eu\/news\/fairsfair-preliminary-recommendations-and-principles-improve-fairness-semantic-artefacts-now" ,
+          },
+          {
+            id : "Standard",
+            acronym : "" ,
+            term : "Standard" ,
+            definition : `1) A level of quality, achievement, etc., that is considered acceptable or desirable.<br>
+                  2) Ideas about morally correct and acceptable behavior.<\/p>
+              <p>A standard can be mandatory due to government statute or regulation, or less formally required in the form of a
+                  consensus or de facto standard. In this context, it is important that the standard is relevant for and used by
+                  a specific community.`,
+            sourceUrl : "https:\/\/www.merriam-webster.com\/dictionary\/standard" ,
+          },
+          {
+            id : "Structured data",
+            acronym : "" ,
+            term : "Structured data" ,
+            definition : `Data whose elements have been organized into a consistent format and data structure within a defined data model
+                  such that the elements can be easily addressed, organized and accessed in various combinations to make better
+                  use of the information, such as in a relational database.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fstructured-data" ,
+          },
+          {
+            id : "TDR",
+            acronym : "TDR" ,
+            term : "Trusted Digital Repository" ,
+            definition : `An infrastructure component that provides reliable, long-term access to managed digital resources. It stores, manages,
+                  and curates digital objects and returns their bit streams when a request is issued. Trusted repositories undergo
+                  regular assessments according to a set of rules such as defined by CoreTrustSeal (CTS) or TRAC (ISO 16363).`,
+            sourceUrl : "https:\/\/casrai-test.evision.ca\/glossary-term\/trusted-digital-repository" ,
+          },
+          {
+            id : "TRUST",
+            acronym : "TRUST" ,
+            term : "TRUST principles" ,
+            definition : `A set of guiding principles to demonstrate digital repository trustworthiness:
+              <ul>
+                  <li>Transparency: to be transparent about specific repository services and data holdings that are verifiable by publicly accessible evidence.<\/li>
+                  <li>Responsibility: to be responsible for ensuring the authenticity of data holdings and for the reliability and persistence of its service.<\/li>
+                  <li>User focus: to ensure that the data management norms and expectations of target user communities are met.<\/li>
+                  <li>Sustainability: to sustain services and preserve data holdings for the long-term.<\/li>
+                  <li>Technology: to provide infrastructure and capabilities to support secure, persistent, and reliable services.<\/li>
+              <\/ul>`,
+            sourceUrl : "https:\/\/doi.org\/10.1038\/s41597-020-0486-7" ,
+          },
+  
         ],
       });
 

--- a/api-fair-impact/src/seeding/seeding.service.ts
+++ b/api-fair-impact/src/seeding/seeding.service.ts
@@ -22,302 +22,6 @@ export class SeedingService {
     try {
       this.logger.log('Starting seeding');
 
-      this.logger.verbose('Seeding Glossary');
-      // TODO use more official glossary information
-      await this.entityManager.save(Glossary, {
-        title: 'Glossary',
-        items: [
-          {
-            id: 'Access',
-            term: 'Access',
-            definition: `The continued, ongoing usability of a digital resource, retaining all qualities of authenticity,
-                accuracy and functionality deemed to be essential for the purposes the digital material was created
-                and/or acquired for. Users who have access can retrieve, manipulate, copy, and store copies on a
-                wide range of hard drives and external devices.`,
-            sourceUrl: 'https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource.html?uri=https://terms.codata.org/rdmt/access',
-            acronym: '',
-          },
-          {
-            id: 'Consent',
-            term: 'Consent form',
-            definition: `According to the GDPR, the processing of personal data requires a legal basis. If consent is this basis,
-                this consent needs to be documented. Consent needs to be freely given, informed, unambiguous, specific
-                and by a clear affirmative action that signifies agreement to the processing of personal data.
-                The consent form is the document where participants indicate their decision of consent. The consent
-                form or the information letter accompanying the form should include information on the research and
-                consequences of participation, as well as information on how resulting data will be processed and shared.`,
-            sourceUrl: 'https:\/\/www.cessda.eu\/Training\/Training-Resources\/Library\/Data-Management-Expert-Guide\/5.-Protect\/Informed-consent',
-            acronym: '',
-          },
-          {
-            id: 'CV',
-            term: 'Controlled Vocabulary',
-            definition: `A controlled vocabulary is a flat, normalised, restricted list of terms for a specific use or context.
-                Thesauri and taxonomies are types of controlled vocabularies, but not all controlled vocabularies
-                are thesauri or taxonomies.`,
-            sourceUrl: 'https:\/\/doi.org\/10.5281\/zenodo.5362010',
-            acronym: 'CV',
-          },
-          {
-            id : "Dataset",
-            acronym : "" ,
-            term : "(Research) Data(set)" ,
-            definition : `Facts, measurements, recordings, records, or observations about the world collected by scientists and others,
-                  with a minimum of contextual interpretation.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata" ,    
-          },				
-          {
-            id : "Data availability statement",
-            acronym : "" ,
-            term : "Data availability statement" ,
-            definition : `A statement accompanying an article published in a scientific journal about the availability of the data
-                  underlying the article. What such a statement looks like is determined by each journal in their data sharing policy.
-                  The statement will usually describe where the data can be found and what access and reuse conditions there are.`,
-            sourceUrl : "https:\/\/libguides.wits.ac.za\/c.php?g=156853&p=6035295" ,
-          },			
-          {
-            id : "Data curation",
-            acronym : "" ,
-            term : "Data curation" ,
-            definition : `A managed process, throughout the data lifecycle, by which data & data collections are cleansed, documented,
-                  standardized, formatted and inter-related.`,
-            sourceUrl : "https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https://terms.codata.org/rdmt/data-curation" ,
-          },
-          {
-            id : "Data destruction",
-            acronym : "" ,
-            term : "Data destruction" ,
-            definition : `The process of destroying data stored on tapes, hard disks and other forms of electronic media so that it is
-                  completely unreadable and cannot be accessed or used.<\/p>
-              <p>In the context of digital data, “Data erasure” or “Data wiping” is the more accurate term. Data wiping is the
-                  process of irreversibly deleting or erasing all data beyond recovery without destruction.<\/p>`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-destruction" ,
-          },					
-          {
-            id : "DMP",
-            acronym : "DMP" ,
-            term : "Data management plan (DMP)" ,
-            definition : `A formal statement describing how research data will be managed and documented throughout a research project and
-                  the terms regarding the subsequent deposit of the data with a data repository for long-term management and preservation.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-management-plan" ,
-          },		
-          {
-            id : "Repository",
-            acronym : "" ,
-            term : "Data repository" ,
-            definition : `Repositories preserve, manage, and provide access to many types of digital materials in a variety of formats.
-                  Materials in online repositories are curated to enable search, discovery, and reuse`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Frepository" ,
-          },				
-          {
-            id : "Retention",
-            acronym : "" ,
-            term : "Data retention" ,
-            definition : `An organization’s established protocol for retaining information for operational or regulatory compliance needs.
-                  The objectives of a data retention policy are to keep important information for future use or reference,
-                  to organize information so it can be searched and accessed at a later date, and to dispose of information that is no longer needed.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-retention-policy/" ,
-          },
-          {
-            id : "stewardship",
-            acronym : "" ,
-            term : "Data stewardship" ,
-            definition : `Data stewardship is a shared responsibility between Principal Investigators and data stewards. Both roles have their
-                  own responsibilities and support roles related to all different parts of the research project.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-stewardship" ,
-          },
-          {
-            id : "Data type",
-            acronym : "" ,
-            term : "Data type" ,
-            definition : `Data type (or simply type) in computer science and computer programming is a classification identifying one of various
-                  types of data, that determines the possible values for that type; the operations that can be done on values of that type;
-                  the meaning of the data; and the way values of that type can be stored.<\/p>
-              <p>Common data types include: integers, booleans, characters, floating-point numbers, alphanumeric strings.`,
-            sourceUrl : "http:\/\/sedataglossary.shoutwiki.com\/wiki\/Data_type" ,
-          },
-          {
-            id : "Preservation",
-            acronym : "" ,
-            term : "Digital preservation" ,
-            definition : `The series of managed activities necessary to ensure continued access to digital materials for as long as necessary.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdigital-preservation" ,
-          },
-          {
-            id : "FAIR",
-            acronym : "FAIR" ,
-            term : "FAIR (Data Principles)" ,
-            definition : `A set of guiding principles to make data Findable, Accessible, Interoperable, and Reusable.
-              <ul>
-                  <li>Findable: (meta)data should be richly described to enable attribute-based search<\/li>
-                  <li>Accessible: (meta)data should be retrievable in a variety of formats that are sensible to humans and
-                      machines using persistent identifiers<\/li>
-                  <li>Interoperable: the description of (meta)data should follow community guidelines that use an open, well defined vocabulary<\\/li>
-                  <li>Reusable: the description of essential, recommended, and optional metadata elements should be machine processable
-                      and verifiable. Use should be easy and data should be citable to sustain data sharing and recognize the value of data<\/li>
-              <\/ul>
-              <p><a href=\"https:\/\/www.force11.org\/group\/fairgroup\/fairprinciples\"<\/a><\/p>`,
-            sourceUrl : "https:\/\/doi.org\/10.1038\/sdata.2016.18" ,
-          },
-          {
-            id : "File format",
-            acronym : "" ,
-            term : "File format" ,
-            definition : `The layout of a file in terms of how the data within the file are organized. A program that uses the data in a file
-                  must be able to recognize and possibly access data within the file. A particular file format is often indicated as
-                  part of a file’s name by a filename extension (suffix). Conventionally, the extension is separated by a period
-                  from the name and contains three or four letters that identify the format.<\/p>
-              <p>A proprietary file format is owned and copyrighted by a specific company. Open file formats are publicly available.</p>
-              <p><a href=\"http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-file-format\"<\/a><\/p>`,
-            sourceUrl : "https:\/\/www.cessda.eu\/Training\/Training-Resources\/Library\/Data-Management-Expert-Guide\/3.-Process\/File-formats-and-data-conversion" ,
-          },
-          {
-            id : "Harvesting",
-            acronym : "" ,
-            term : "Harvesting" ,
-            definition : `Metadata harvesting is an automated, regular process of collecting metadata descriptions from different sources to create
-                  useful aggregations, so that services can be built using metadata from many repositories.`,
-            sourceUrl : "http:\/\/sedataglossary.shoutwiki.com\/wiki\/Metadata_harvesting" ,
-          },
-          {
-            id : "Licence",
-            acronym : "" ,
-            term : "Licence" ,
-            definition : `A signed agreement to exploit a piece of IP such as a process, product, data, or software. An official document that gives
-                  you permission to own, do, or use something, usually after you have paid money and/or taken a test. Commonly used
-                  licences for open access works include Creative Commons licences. In the UK context, information about licences can be
-                  obtained from the IPO (Intellectual Property Office).`,
-            sourceUrl : "https://www.wikidata.org/wiki/Q79719" ,
-          },
-          {
-            id : "Link rot",
-            acronym : "" ,
-            term : "Link rot" ,
-            definition : `Link rot (also called link death, link breaking, or reference rot) is the disassociation between web addresses and their
-                  content. It’s the phenomenon of hyperlinks tending over time to cease to point to their originally targeted file, web page,
-                  or server due to that resource being relocated to a new address or becoming permanently unavailable.`,
-            sourceUrl : "https:\/\/dictionary.archivists.org\/entry\/link-rot.html" ,
-          },
-          {
-            id : "Long-term preservation",
-            acronym : "LTP" ,
-            term : "Long-term preservation" ,
-            definition : `Continued access to digital materials, or at least to the information contained in them, indefinitely.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Flong-term-preservation" ,
-          },
-          {
-            id : "Machine-actionable",
-            acronym : "" ,
-            term : "Machine-actionable" ,
-            definition : `A continuum of possible states wherein a digital object provides increasingly more detailed information to an
-                  autonomously-acting, computational data explorer. This information enables the agent—to a degree dependent on
-                  the amount of detail provided—to have the capacity, when faced with a digital object never encountered before, to:
-              <ol type=\"a\">
-                  <li>identify the type of object (with respect to both structure and intent), <\/li>
-                  <li>determine if it is useful within the context of the agent’s current task by interrogating metadata and/or data elements, <\/li>
-                  <li>determine if it is usable, with respect to license, consent, or other accessibility or use constraints, and <\/li>
-                  <li>take appropriate action, in much the same manner that a human would.<\/li>
-              <\/ol>`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmachine-actionable" ,
-          },
-          {
-            id : "Machine-readable",
-            acronym : "" ,
-            term : "Machine-readable format" ,
-            definition : `In a form that can be used and understood by a computer. A broad term encompassing: (a) digital surrogates created
-                  as a result of converting analogue materials to digital form (digitisation); (b) “born digital” for which there
-                  has never been and is never intended to be an analogue equivalent; and, (c) digital records.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmachine-readable" ,
-          },
-          {
-            id : "Metadata",
-            acronym : "" ,
-            term : "Metadata" ,
-            definition : `Data that defines and describes the characteristics of other data, used to improve both business and technical
-                  understanding of data and data-related processes.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmetadata" ,
-          },
-          {
-            id : "PID",
-            acronym : "PID" ,
-            term : "Persistent Identifier" ,
-            definition : `A persistent identifier is a long-lasting reference to a digital object that gives information about that object regardless
-                  of what happens to it. Developed to address “link rot,” a persistent identifier can be resolved to provide an appropriate
-                  representation of an object whether that object changes its online location or goes offline.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fpersistent-identifier" ,
-          },
-          {
-            id : "Preservation plan",
-            acronym : "" ,
-            term : "Preservation plan / policy" ,
-            definition : `A preservation plan outlines the principles steering the main activities regarding sustainable preservation of, as well as
-                  access to digital research data for, (re-)use within its user communities.`,
-            sourceUrl : "https:\/\/dans.knaw.nl\/en\/about\/strategy" ,
-          },
-          {
-            id : "Provenance",
-            acronym : "" ,
-            term : "Provenance" ,
-            definition : `A type of historical information or metadata about the origin, location or the source of something, or the history of
-                  the ownership or location of an object or resource including digital objects. For example, information about the
-                  Principal Investigator who recorded the data, and the information concerning its storage, handling, and migration`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fprovenance" ,
-          },
-          {
-            id : "SA",
-            acronym : "SA" ,
-            term : "Semantic artefact" ,
-            definition : `Semantic artefacts are machine readable models of knowledge such as controlled vocabularies, thesauri, and ontologies
-                  which facilitate the extraction and representation of knowledge within data sets using annotations or assertions.`,
-            sourceUrl : "https:\/\/www.fairsfair.eu\/news\/fairsfair-preliminary-recommendations-and-principles-improve-fairness-semantic-artefacts-now" ,
-          },
-          {
-            id : "Standard",
-            acronym : "" ,
-            term : "Standard" ,
-            definition : `1) A level of quality, achievement, etc., that is considered acceptable or desirable.<br>
-                  2) Ideas about morally correct and acceptable behavior.<\/p>
-              <p>A standard can be mandatory due to government statute or regulation, or less formally required in the form of a
-                  consensus or de facto standard. In this context, it is important that the standard is relevant for and used by
-                  a specific community.`,
-            sourceUrl : "https:\/\/www.merriam-webster.com\/dictionary\/standard" ,
-          },
-          {
-            id : "Structured data",
-            acronym : "" ,
-            term : "Structured data" ,
-            definition : `Data whose elements have been organized into a consistent format and data structure within a defined data model
-                  such that the elements can be easily addressed, organized and accessed in various combinations to make better
-                  use of the information, such as in a relational database.`,
-            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fstructured-data" ,
-          },
-          {
-            id : "TDR",
-            acronym : "TDR" ,
-            term : "Trusted Digital Repository" ,
-            definition : `An infrastructure component that provides reliable, long-term access to managed digital resources. It stores, manages,
-                  and curates digital objects and returns their bit streams when a request is issued. Trusted repositories undergo
-                  regular assessments according to a set of rules such as defined by CoreTrustSeal (CTS) or TRAC (ISO 16363).`,
-            sourceUrl : "https:\/\/casrai-test.evision.ca\/glossary-term\/trusted-digital-repository" ,
-          },
-          {
-            id : "TRUST",
-            acronym : "TRUST" ,
-            term : "TRUST principles" ,
-            definition : `A set of guiding principles to demonstrate digital repository trustworthiness:
-              <ul>
-                  <li>Transparency: to be transparent about specific repository services and data holdings that are verifiable by publicly accessible evidence.<\/li>
-                  <li>Responsibility: to be responsible for ensuring the authenticity of data holdings and for the reliability and persistence of its service.<\/li>
-                  <li>User focus: to ensure that the data management norms and expectations of target user communities are met.<\/li>
-                  <li>Sustainability: to sustain services and preserve data holdings for the long-term.<\/li>
-                  <li>Technology: to provide infrastructure and capabilities to support secure, persistent, and reliable services.<\/li>
-              <\/ul>`,
-            sourceUrl : "https:\/\/doi.org\/10.1038\/s41597-020-0486-7" ,
-          },
-  
-        ],
-      });
-
       this.logger.verbose('Seeding languages');
       await this.entityManager.upsert(Language, languageSeeds, {
         conflictPaths: ['code'],
@@ -769,6 +473,304 @@ export class SeedingService {
           },
         });
       }
+
+      this.logger.verbose('Seeding Glossary');
+      // TODO use more official glossary information
+      await this.entityManager.save(Glossary, {
+        digitalObjectType: { ...digitalObjectTypes[0] },
+        language: { ...english },
+        title: 'Glossary',
+        items: [
+          {
+            id: 'Access',
+            term: 'Access',
+            definition: `The continued, ongoing usability of a digital resource, retaining all qualities of authenticity,
+                accuracy and functionality deemed to be essential for the purposes the digital material was created
+                and/or acquired for. Users who have access can retrieve, manipulate, copy, and store copies on a
+                wide range of hard drives and external devices.`,
+            sourceUrl: 'https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource.html?uri=https://terms.codata.org/rdmt/access',
+            acronym: '',
+          },
+          {
+            id: 'Consent',
+            term: 'Consent form',
+            definition: `According to the GDPR, the processing of personal data requires a legal basis. If consent is this basis,
+                this consent needs to be documented. Consent needs to be freely given, informed, unambiguous, specific
+                and by a clear affirmative action that signifies agreement to the processing of personal data.
+                The consent form is the document where participants indicate their decision of consent. The consent
+                form or the information letter accompanying the form should include information on the research and
+                consequences of participation, as well as information on how resulting data will be processed and shared.`,
+            sourceUrl: 'https:\/\/www.cessda.eu\/Training\/Training-Resources\/Library\/Data-Management-Expert-Guide\/5.-Protect\/Informed-consent',
+            acronym: '',
+          },
+          {
+            id: 'CV',
+            term: 'Controlled Vocabulary',
+            definition: `A controlled vocabulary is a flat, normalised, restricted list of terms for a specific use or context.
+                Thesauri and taxonomies are types of controlled vocabularies, but not all controlled vocabularies
+                are thesauri or taxonomies.`,
+            sourceUrl: 'https:\/\/doi.org\/10.5281\/zenodo.5362010',
+            acronym: 'CV',
+          },
+          {
+            id : "Dataset",
+            acronym : "" ,
+            term : "(Research) Data(set)" ,
+            definition : `Facts, measurements, recordings, records, or observations about the world collected by scientists and others,
+                  with a minimum of contextual interpretation.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata" ,    
+          },				
+          {
+            id : "Data availability statement",
+            acronym : "" ,
+            term : "Data availability statement" ,
+            definition : `A statement accompanying an article published in a scientific journal about the availability of the data
+                  underlying the article. What such a statement looks like is determined by each journal in their data sharing policy.
+                  The statement will usually describe where the data can be found and what access and reuse conditions there are.`,
+            sourceUrl : "https:\/\/libguides.wits.ac.za\/c.php?g=156853&p=6035295" ,
+          },			
+          {
+            id : "Data curation",
+            acronym : "" ,
+            term : "Data curation" ,
+            definition : `A managed process, throughout the data lifecycle, by which data & data collections are cleansed, documented,
+                  standardized, formatted and inter-related.`,
+            sourceUrl : "https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https://terms.codata.org/rdmt/data-curation" ,
+          },
+          {
+            id : "Data destruction",
+            acronym : "" ,
+            term : "Data destruction" ,
+            definition : `The process of destroying data stored on tapes, hard disks and other forms of electronic media so that it is
+                  completely unreadable and cannot be accessed or used.<\/p>
+              <p>In the context of digital data, “Data erasure” or “Data wiping” is the more accurate term. Data wiping is the
+                  process of irreversibly deleting or erasing all data beyond recovery without destruction.<\/p>`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-destruction" ,
+          },					
+          {
+            id : "DMP",
+            acronym : "DMP" ,
+            term : "Data management plan (DMP)" ,
+            definition : `A formal statement describing how research data will be managed and documented throughout a research project and
+                  the terms regarding the subsequent deposit of the data with a data repository for long-term management and preservation.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-management-plan" ,
+          },		
+          {
+            id : "Repository",
+            acronym : "" ,
+            term : "Data repository" ,
+            definition : `Repositories preserve, manage, and provide access to many types of digital materials in a variety of formats.
+                  Materials in online repositories are curated to enable search, discovery, and reuse`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Frepository" ,
+          },				
+          {
+            id : "Retention",
+            acronym : "" ,
+            term : "Data retention" ,
+            definition : `An organization’s established protocol for retaining information for operational or regulatory compliance needs.
+                  The objectives of a data retention policy are to keep important information for future use or reference,
+                  to organize information so it can be searched and accessed at a later date, and to dispose of information that is no longer needed.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-retention-policy/" ,
+          },
+          {
+            id : "stewardship",
+            acronym : "" ,
+            term : "Data stewardship" ,
+            definition : `Data stewardship is a shared responsibility between Principal Investigators and data stewards. Both roles have their
+                  own responsibilities and support roles related to all different parts of the research project.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-stewardship" ,
+          },
+          {
+            id : "Data type",
+            acronym : "" ,
+            term : "Data type" ,
+            definition : `Data type (or simply type) in computer science and computer programming is a classification identifying one of various
+                  types of data, that determines the possible values for that type; the operations that can be done on values of that type;
+                  the meaning of the data; and the way values of that type can be stored.<\/p>
+              <p>Common data types include: integers, booleans, characters, floating-point numbers, alphanumeric strings.`,
+            sourceUrl : "http:\/\/sedataglossary.shoutwiki.com\/wiki\/Data_type" ,
+          },
+          {
+            id : "Preservation",
+            acronym : "" ,
+            term : "Digital preservation" ,
+            definition : `The series of managed activities necessary to ensure continued access to digital materials for as long as necessary.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdigital-preservation" ,
+          },
+          {
+            id : "FAIR",
+            acronym : "FAIR" ,
+            term : "FAIR (Data Principles)" ,
+            definition : `A set of guiding principles to make data Findable, Accessible, Interoperable, and Reusable.
+              <ul>
+                  <li>Findable: (meta)data should be richly described to enable attribute-based search<\/li>
+                  <li>Accessible: (meta)data should be retrievable in a variety of formats that are sensible to humans and
+                      machines using persistent identifiers<\/li>
+                  <li>Interoperable: the description of (meta)data should follow community guidelines that use an open, well defined vocabulary<\\/li>
+                  <li>Reusable: the description of essential, recommended, and optional metadata elements should be machine processable
+                      and verifiable. Use should be easy and data should be citable to sustain data sharing and recognize the value of data<\/li>
+              <\/ul>
+              <p><a href=\"https:\/\/www.force11.org\/group\/fairgroup\/fairprinciples\"<\/a><\/p>`,
+            sourceUrl : "https:\/\/doi.org\/10.1038\/sdata.2016.18" ,
+          },
+          {
+            id : "File format",
+            acronym : "" ,
+            term : "File format" ,
+            definition : `The layout of a file in terms of how the data within the file are organized. A program that uses the data in a file
+                  must be able to recognize and possibly access data within the file. A particular file format is often indicated as
+                  part of a file’s name by a filename extension (suffix). Conventionally, the extension is separated by a period
+                  from the name and contains three or four letters that identify the format.<\/p>
+              <p>A proprietary file format is owned and copyrighted by a specific company. Open file formats are publicly available.</p>
+              <p><a href=\"http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fdata-file-format\"<\/a><\/p>`,
+            sourceUrl : "https:\/\/www.cessda.eu\/Training\/Training-Resources\/Library\/Data-Management-Expert-Guide\/3.-Process\/File-formats-and-data-conversion" ,
+          },
+          {
+            id : "Harvesting",
+            acronym : "" ,
+            term : "Harvesting" ,
+            definition : `Metadata harvesting is an automated, regular process of collecting metadata descriptions from different sources to create
+                  useful aggregations, so that services can be built using metadata from many repositories.`,
+            sourceUrl : "http:\/\/sedataglossary.shoutwiki.com\/wiki\/Metadata_harvesting" ,
+          },
+          {
+            id : "Licence",
+            acronym : "" ,
+            term : "Licence" ,
+            definition : `A signed agreement to exploit a piece of IP such as a process, product, data, or software. An official document that gives
+                  you permission to own, do, or use something, usually after you have paid money and/or taken a test. Commonly used
+                  licences for open access works include Creative Commons licences. In the UK context, information about licences can be
+                  obtained from the IPO (Intellectual Property Office).`,
+            sourceUrl : "https://www.wikidata.org/wiki/Q79719" ,
+          },
+          {
+            id : "Link rot",
+            acronym : "" ,
+            term : "Link rot" ,
+            definition : `Link rot (also called link death, link breaking, or reference rot) is the disassociation between web addresses and their
+                  content. It’s the phenomenon of hyperlinks tending over time to cease to point to their originally targeted file, web page,
+                  or server due to that resource being relocated to a new address or becoming permanently unavailable.`,
+            sourceUrl : "https:\/\/dictionary.archivists.org\/entry\/link-rot.html" ,
+          },
+          {
+            id : "Long-term preservation",
+            acronym : "LTP" ,
+            term : "Long-term preservation" ,
+            definition : `Continued access to digital materials, or at least to the information contained in them, indefinitely.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Flong-term-preservation" ,
+          },
+          {
+            id : "Machine-actionable",
+            acronym : "" ,
+            term : "Machine-actionable" ,
+            definition : `A continuum of possible states wherein a digital object provides increasingly more detailed information to an
+                  autonomously-acting, computational data explorer. This information enables the agent—to a degree dependent on
+                  the amount of detail provided—to have the capacity, when faced with a digital object never encountered before, to:
+              <ol type=\"a\">
+                  <li>identify the type of object (with respect to both structure and intent), <\/li>
+                  <li>determine if it is useful within the context of the agent’s current task by interrogating metadata and/or data elements, <\/li>
+                  <li>determine if it is usable, with respect to license, consent, or other accessibility or use constraints, and <\/li>
+                  <li>take appropriate action, in much the same manner that a human would.<\/li>
+              <\/ol>`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmachine-actionable" ,
+          },
+          {
+            id : "Machine-readable",
+            acronym : "" ,
+            term : "Machine-readable format" ,
+            definition : `In a form that can be used and understood by a computer. A broad term encompassing: (a) digital surrogates created
+                  as a result of converting analogue materials to digital form (digitisation); (b) “born digital” for which there
+                  has never been and is never intended to be an analogue equivalent; and, (c) digital records.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmachine-readable" ,
+          },
+          {
+            id : "Metadata",
+            acronym : "" ,
+            term : "Metadata" ,
+            definition : `Data that defines and describes the characteristics of other data, used to improve both business and technical
+                  understanding of data and data-related processes.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fmetadata" ,
+          },
+          {
+            id : "PID",
+            acronym : "PID" ,
+            term : "Persistent Identifier" ,
+            definition : `A persistent identifier is a long-lasting reference to a digital object that gives information about that object regardless
+                  of what happens to it. Developed to address “link rot,” a persistent identifier can be resolved to provide an appropriate
+                  representation of an object whether that object changes its online location or goes offline.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fpersistent-identifier" ,
+          },
+          {
+            id : "Preservation plan",
+            acronym : "" ,
+            term : "Preservation plan / policy" ,
+            definition : `A preservation plan outlines the principles steering the main activities regarding sustainable preservation of, as well as
+                  access to digital research data for, (re-)use within its user communities.`,
+            sourceUrl : "https:\/\/dans.knaw.nl\/en\/about\/strategy" ,
+          },
+          {
+            id : "Provenance",
+            acronym : "" ,
+            term : "Provenance" ,
+            definition : `A type of historical information or metadata about the origin, location or the source of something, or the history of
+                  the ownership or location of an object or resource including digital objects. For example, information about the
+                  Principal Investigator who recorded the data, and the information concerning its storage, handling, and migration`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fprovenance" ,
+          },
+          {
+            id : "SA",
+            acronym : "SA" ,
+            term : "Semantic artefact" ,
+            definition : `Semantic artefacts are machine readable models of knowledge such as controlled vocabularies, thesauri, and ontologies
+                  which facilitate the extraction and representation of knowledge within data sets using annotations or assertions.`,
+            sourceUrl : "https:\/\/www.fairsfair.eu\/news\/fairsfair-preliminary-recommendations-and-principles-improve-fairness-semantic-artefacts-now" ,
+          },
+          {
+            id : "Standard",
+            acronym : "" ,
+            term : "Standard" ,
+            definition : `1) A level of quality, achievement, etc., that is considered acceptable or desirable.<br>
+                  2) Ideas about morally correct and acceptable behavior.<\/p>
+              <p>A standard can be mandatory due to government statute or regulation, or less formally required in the form of a
+                  consensus or de facto standard. In this context, it is important that the standard is relevant for and used by
+                  a specific community.`,
+            sourceUrl : "https:\/\/www.merriam-webster.com\/dictionary\/standard" ,
+          },
+          {
+            id : "Structured data",
+            acronym : "" ,
+            term : "Structured data" ,
+            definition : `Data whose elements have been organized into a consistent format and data structure within a defined data model
+                  such that the elements can be easily addressed, organized and accessed in various combinations to make better
+                  use of the information, such as in a relational database.`,
+            sourceUrl : "http://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v001/resource?uri=https%3A%2F%2Fterms.codata.org%2Frdmt%2Fstructured-data" ,
+          },
+          {
+            id : "TDR",
+            acronym : "TDR" ,
+            term : "Trusted Digital Repository" ,
+            definition : `An infrastructure component that provides reliable, long-term access to managed digital resources. It stores, manages,
+                  and curates digital objects and returns their bit streams when a request is issued. Trusted repositories undergo
+                  regular assessments according to a set of rules such as defined by CoreTrustSeal (CTS) or TRAC (ISO 16363).`,
+            sourceUrl : "https:\/\/casrai-test.evision.ca\/glossary-term\/trusted-digital-repository" ,
+          },
+          {
+            id : "TRUST",
+            acronym : "TRUST" ,
+            term : "TRUST principles" ,
+            definition : `A set of guiding principles to demonstrate digital repository trustworthiness:
+              <ul>
+                  <li>Transparency: to be transparent about specific repository services and data holdings that are verifiable by publicly accessible evidence.<\/li>
+                  <li>Responsibility: to be responsible for ensuring the authenticity of data holdings and for the reliability and persistence of its service.<\/li>
+                  <li>User focus: to ensure that the data management norms and expectations of target user communities are met.<\/li>
+                  <li>Sustainability: to sustain services and preserve data holdings for the long-term.<\/li>
+                  <li>Technology: to provide infrastructure and capabilities to support secure, persistent, and reliable services.<\/li>
+              <\/ul>`,
+            sourceUrl : "https:\/\/doi.org\/10.1038\/s41597-020-0486-7" ,
+          },
+  
+        ],
+      });
 
       this.logger.log('Seeding complete.');
     } catch (error) {

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -2,6 +2,7 @@
 
 import Breadcrumbs from "@/components/beardcrumbs";
 import useGlossary from "@/hooks/use-glossary";
+import Link from "next/link";
 
 export default function ClientPage({ uuid }: { uuid: string }) {
   const { data, isLoading, isError } = useGlossary(uuid);
@@ -51,15 +52,36 @@ export default function ClientPage({ uuid }: { uuid: string }) {
       <h2 className="mt-8 border-t border-gray-500 pt-8 text-base/7 font-semibold text-gray-900">
         Glossary items
       </h2>
-      {data.items.map((item, index) => (
+      {data.items.map((item) => (
         <div
-          key={index}
-          className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 border-t border-gray-300 sm:grid-cols-6"
+          key={item.uuid}
+          className="py-6 mt-10 grid grid-cols-1 gap-x-6 gap-y-8 border-t border-gray-300 sm:grid-cols-6"
         >
           <div className="sm:col-span-6">
-            <label className="block text-sm/6 font-medium text-gray-900"></label>
+            <label className="block text-sm/6 font-medium text-gray-900">
+              ID
+            </label>
             <div className="mt-2">
-              <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+                {item.id}
+              </p>
+            </div>
+          </div>
+          <div className="sm:col-span-6">
+            <label className="block text-sm/6 font-medium text-gray-900">
+              Acronym
+            </label>
+            <div className="mt-2">
+            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+                {item.acronym}
+              </p>
+            </div>
+          </div>
+          <div className="sm:col-span-6">
+            <label className="block text-sm/6 font-medium text-gray-900">
+              Term</label>
+            <div className="mt-2">
+            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
                 {item.term}
               </p>
             </div>
@@ -71,6 +93,21 @@ export default function ClientPage({ uuid }: { uuid: string }) {
             <div className="mt-2">
               <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
                 {item.definition}
+              </p>
+            </div>
+          </div>
+          <div className="sm:col-span-6">
+            <label className="block text-sm/6 font-medium text-gray-900">
+              Source URL</label>
+            <div className="mt-2">
+            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+                {item.sourceUrl ? (
+                  <Link href={item.sourceUrl} target="_blank" rel="noopener noreferrer">
+                    {item.sourceUrl}
+                  </Link>
+                ) : (
+                  <span className="text-gray-600">No source available</span>
+                )}
               </p>
             </div>
           </div>

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -55,14 +55,14 @@ export default function ClientPage({ uuid }: { uuid: string }) {
       {data.items.map((item) => (
         <div
           key={item.uuid}
-          className="py-6 mt-10 grid grid-cols-1 gap-x-6 gap-y-8 border-t border-gray-300 sm:grid-cols-6"
+          className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 border-t border-gray-300 py-6 sm:grid-cols-6"
         >
           <div className="sm:col-span-6">
             <label className="block text-sm/6 font-medium text-gray-900">
               ID
             </label>
             <div className="mt-2">
-            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+              <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
                 {item.id}
               </p>
             </div>
@@ -72,16 +72,17 @@ export default function ClientPage({ uuid }: { uuid: string }) {
               Acronym
             </label>
             <div className="mt-2">
-            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+              <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
                 {item.acronym}
               </p>
             </div>
           </div>
           <div className="sm:col-span-6">
             <label className="block text-sm/6 font-medium text-gray-900">
-              Term</label>
+              Term
+            </label>
             <div className="mt-2">
-            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+              <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
                 {item.term}
               </p>
             </div>
@@ -98,11 +99,16 @@ export default function ClientPage({ uuid }: { uuid: string }) {
           </div>
           <div className="sm:col-span-6">
             <label className="block text-sm/6 font-medium text-gray-900">
-              Source URL</label>
+              Source URL
+            </label>
             <div className="mt-2">
-            <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
+              <p className="block min-h-[2.375rem] w-full rounded-md border border-gray-300 bg-gray-400/5 px-3 py-1.5 text-base text-gray-900 sm:text-sm/6">
                 {item.sourceUrl ? (
-                  <Link href={item.sourceUrl} target="_blank" rel="noopener noreferrer">
+                  <Link
+                    href={item.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     {item.sourceUrl}
                   </Link>
                 ) : (

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -48,6 +48,26 @@ export default function ClientPage({ uuid }: { uuid: string }) {
             </p>
           </div>
         </div>
+        <div className="sm:col-span-3">
+          <label className="block text-sm/6 font-medium text-gray-900">
+            DOT Code
+          </label>
+          <div className="mt-2">
+            <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+              {data.digitalObjectType.code}
+            </p>
+          </div>
+        </div>
+        <div className="sm:col-span-3">
+          <label className="block text-sm/6 font-medium text-gray-900">
+            Language
+          </label>
+          <div className="mt-2">
+            <p className="block w-full py-1.5 text-base font-bold text-gray-600 sm:text-sm/6">
+              {data.language.englishLabel}
+            </p>
+          </div>
+        </div>
       </div>
       <h2 className="mt-8 border-t border-gray-500 pt-8 text-base/7 font-semibold text-gray-900">
         Glossary items

--- a/client-fair-impact/app/cms/glossaries/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/client.tsx
@@ -37,10 +37,14 @@ export default function GlossariesClientPage() {
               <span className="font-bold">{glossary.title}</span>
             </TableCell>
             <TableCell>
-              <span className="font-bold">{glossary.digitalObjectType.code}</span>
+              <span className="font-bold">
+                {glossary.digitalObjectType.code}
+              </span>
             </TableCell>
             <TableCell>
-              <span className="font-bold">{glossary.language.englishLabel}</span>
+              <span className="font-bold">
+                {glossary.language.englishLabel}
+              </span>
             </TableCell>
             <TableCell>{TimestampzToDate(glossary.updatedAt)}</TableCell>
             <TableCell>{TimestampzToDate(glossary.createdAt)}</TableCell>

--- a/client-fair-impact/app/cms/glossaries/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/client.tsx
@@ -38,12 +38,16 @@ export default function GlossariesClientPage() {
             </TableCell>
             <TableCell>
               <span className="font-bold">
-                {glossary.digitalObjectType.code}
+                {
+                  glossary.digitalObjectType?.code ?? "" // prevent prerendering problem
+                }
               </span>
             </TableCell>
             <TableCell>
               <span className="font-bold">
-                {glossary.language.englishLabel}
+                {
+                  glossary.language?.englishLabel ?? "" // prevent prerendering problem
+                }
               </span>
             </TableCell>
             <TableCell>{TimestampzToDate(glossary.updatedAt)}</TableCell>

--- a/client-fair-impact/app/cms/glossaries/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/client.tsx
@@ -11,9 +11,9 @@ export default function GlossariesClientPage() {
   const { data, isLoading, isError } = useGlossaries();
 
   const tableHeaders = [
-    //"DOT Code",
-    //"Language",
     "Title",
+    "DOT Code",
+    "Language",
     "Modified At",
     "Created At",
     "",
@@ -36,17 +36,12 @@ export default function GlossariesClientPage() {
             <TableCell>
               <span className="font-bold">{glossary.title}</span>
             </TableCell>
-            {/* <TableCell>
-              <span className="font-bold">{clms.digitalObjectType.code}</span>
+            <TableCell>
+              <span className="font-bold">{glossary.digitalObjectType.code}</span>
             </TableCell>
             <TableCell>
-              <span className="font-bold">{clms.language.englishLabel}</span>
+              <span className="font-bold">{glossary.language.englishLabel}</span>
             </TableCell>
-            <TableCell>
-              <span className="font-bold">
-                {clms.digitalObjectTypeSchema.version}
-              </span>
-            </TableCell> */}
             <TableCell>{TimestampzToDate(glossary.updatedAt)}</TableCell>
             <TableCell>{TimestampzToDate(glossary.createdAt)}</TableCell>
             <TableCell>

--- a/client-fair-impact/app/cms/glossaries/page.tsx
+++ b/client-fair-impact/app/cms/glossaries/page.tsx
@@ -1,5 +1,8 @@
+import "server-only";
+
 import Breadcrumbs from "@/components/beardcrumbs";
-import { fetchGlossaries } from "@/hooks/use-glossaries";
+import { fetchGlossaries } from "@/hooks/fetch-glossaries";
+
 import {
   dehydrate,
   HydrationBoundary,

--- a/client-fair-impact/app/glossary/client.tsx
+++ b/client-fair-impact/app/glossary/client.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import useGlossaryByLanguageAndDOT from "@/hooks/use-glossary-by-language-and-dot copy";
+import Link from "next/link";
+
+export default function ClientPage() {
+  const {
+    data: glossary,
+    isLoading,
+    isError,
+  } = useGlossaryByLanguageAndDOT("en", "DATA"); // just get fixed one for now
+
+  if (isLoading) {
+    return <h1 className="text-2xl font-bold text-gray-800">Loading...</h1>;
+  }
+
+  if (isError || !glossary) {
+    return <h1 className="text-2xl font-bold text-gray-800">Error</h1>;
+  }
+
+  return (
+    <>
+      <main className="mx-auto max-w-7xl px-2 lg:px-8">
+        {/* <h1>Glossary</h1> */}
+        {glossary && (
+          <h1
+            className="text-3xl font-bold text-gray-700"
+            style={{ textTransform: "uppercase" }}
+          >
+            {glossary.title}
+          </h1>
+        )}
+        {glossary && (
+          <div className="py-6">
+            <ul style={{ listStyleType: "none", padding: 0 }}>
+              {glossary.items
+                .sort((a, b) => a.term.localeCompare(b.term))
+                .map((item) => (
+                  <li
+                    key={item.uuid}
+                    style={{ marginBottom: "20px" }}
+                    id={item.uuid}
+                  >
+                    <strong>{item.term}</strong>
+                    {item.acronym && (
+                      <span style={{ marginLeft: "10px" }}>
+                        <em>({item.acronym})</em>
+                      </span>
+                    )}
+                    <p>{item.definition}</p>
+                    <div>
+                      {item.sourceUrl && (
+                        <Link
+                          href={item.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {item.sourceUrl}
+                        </Link>
+                      )}
+                    </div>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -1,85 +1,29 @@
-"use client";
+import "server-only";
 
 import Footer from "@/components/footer/footer";
 import Header from "@/components/header/header";
-import useGlossaries, { fetchGlossaries } from "@/hooks/use-glossaries";
-import useGlossary, { fetchGlossary } from "@/hooks/use-glossary";
-import { IGlossaries, IGlossary } from "@/types/entities/glossary.interface";
-import { QueryClient } from "@tanstack/react-query";
-import Link from "next/link";
-import React, { use } from "react";
+import { fetchGlossaryByLanguageAndDOT } from "@/hooks/use-glossary-by-language-and-dot copy";
 
-export default function GlossaryPage() {
-  // const queryClient = new QueryClient();
-  // await queryClient.prefetchQuery({
-  //   queryKey: ["glossaries"],
-  //   queryFn: () => fetchGlossaries(), // just get them all for now
-  // });
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 
-  // use fetchGlossaries hook, just get them all for now
-  //const glossaries: IGlossaries[] = await fetchGlossaries();
-  const { data: glossaries, isSuccess: glossariesDone, isError: glossariesError } = useGlossaries();
-  const { data: glossary, isLoading, isError } = useGlossary(glossaries![glossaries!.length - 1].uuid, glossariesDone)
-
-  // take the last glossary,
-  // but we should get the one matching the selected DOT and language at some point
-  // const glossary: IGlossary = await fetchGlossary(
-  //   glossaries[glossaries.length - 1].uuid,
-  // );
-
-  if (isLoading || isError ) {
-    return <p>SOMETHING WENT WRONG : D</p>
-  }
+import GlossaryClient from "./client";
+export default async function GlossaryPage() {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["glossary", "en", "DATA"], // just get fixed one for now
+    queryFn: () => fetchGlossaryByLanguageAndDOT("en", "DATA"), // just get fixed one for now
+  });
 
   return (
     <>
       <Header />
-      <main className="mx-auto max-w-7xl px-2 lg:px-8">
-        {/* <h1>Glossary</h1> */}
-        {glossary && (
-          <h1
-            className="text-3xl font-bold text-gray-700"
-            style={{ textTransform: "uppercase" }}
-          >
-            {glossary.title}
-          </h1>
-        )}
-        {glossary && (
-          // display the terms
-          <div className="py-6">
-            <ul style={{ listStyleType: "none", padding: 0 }}>
-              {glossary.items
-                .sort((a, b) => a.term.localeCompare(b.term)) // Sort items by term
-                .map((item) => (
-                  <li
-                    key={item.uuid}
-                    style={{ marginBottom: "20px" }}
-                    id={item.uuid}
-                  >
-                    <strong>{item.term}</strong>
-                    {item.acronym && (
-                      <span style={{ marginLeft: "10px" }}>
-                        <em>({item.acronym})</em>
-                      </span>
-                    )}
-                    <p>{item.definition}</p>
-                    <div>
-                      {item.sourceUrl && (
-                        <Link
-                          href={item.sourceUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {item.sourceUrl}
-                        </Link>
-                      )}
-                    </div>
-                  </li>
-                ))}
-            </ul>
-          </div>
-        )}
-      </main>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <GlossaryClient />
+      </HydrationBoundary>
       <Footer />
     </>
   );

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -1,12 +1,15 @@
+"use client";
+
 import Footer from "@/components/footer/footer";
 import Header from "@/components/header/header";
-import { fetchGlossaries } from "@/hooks/use-glossaries";
-import { fetchGlossary } from "@/hooks/use-glossary";
+import useGlossaries, { fetchGlossaries } from "@/hooks/use-glossaries";
+import useGlossary, { fetchGlossary } from "@/hooks/use-glossary";
 import { IGlossaries, IGlossary } from "@/types/entities/glossary.interface";
+import { QueryClient } from "@tanstack/react-query";
 import Link from "next/link";
-import React from "react";
+import React, { use } from "react";
 
-export default async function GlossaryPage() {
+export default function GlossaryPage() {
   // const queryClient = new QueryClient();
   // await queryClient.prefetchQuery({
   //   queryKey: ["glossaries"],
@@ -14,12 +17,19 @@ export default async function GlossaryPage() {
   // });
 
   // use fetchGlossaries hook, just get them all for now
-  const glossaries: IGlossaries[] = await fetchGlossaries();
+  //const glossaries: IGlossaries[] = await fetchGlossaries();
+  const { data: glossaries, isSuccess: glossariesDone, isError: glossariesError } = useGlossaries();
+  const { data: glossary, isLoading, isError } = useGlossary(glossaries![glossaries!.length - 1].uuid, glossariesDone)
+
   // take the last glossary,
   // but we should get the one matching the selected DOT and language at some point
-  const glossary: IGlossary = await fetchGlossary(
-    glossaries[glossaries.length - 1].uuid,
-  );
+  // const glossary: IGlossary = await fetchGlossary(
+  //   glossaries[glossaries.length - 1].uuid,
+  // );
+
+  if (isLoading || isError ) {
+    return <p>SOMETHING WENT WRONG : D</p>
+  }
 
   return (
     <>
@@ -38,32 +48,32 @@ export default async function GlossaryPage() {
           // display the terms
           <div className="py-6">
             <ul style={{ listStyleType: "none", padding: 0 }}>
-                {glossary.items
+              {glossary.items
                 .sort((a, b) => a.term.localeCompare(b.term)) // Sort items by term
                 .map((item) => (
                   <li
-                  key={item.uuid}
-                  style={{ marginBottom: "20px" }}
-                  id={item.uuid}
+                    key={item.uuid}
+                    style={{ marginBottom: "20px" }}
+                    id={item.uuid}
                   >
-                  <strong>{item.term}</strong>
-                  {item.acronym && (
-                    <span style={{ marginLeft: "10px" }}>
-                    <em>({item.acronym})</em>
-                    </span>
-                  )}
-                  <p>{item.definition}</p>
-                  <div>
-                    {item.sourceUrl && (
-                    <Link
-                      href={item.sourceUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {item.sourceUrl}
-                    </Link>
+                    <strong>{item.term}</strong>
+                    {item.acronym && (
+                      <span style={{ marginLeft: "10px" }}>
+                        <em>({item.acronym})</em>
+                      </span>
                     )}
-                  </div>
+                    <p>{item.definition}</p>
+                    <div>
+                      {item.sourceUrl && (
+                        <Link
+                          href={item.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {item.sourceUrl}
+                        </Link>
+                      )}
+                    </div>
                   </li>
                 ))}
             </ul>

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -38,34 +38,34 @@ export default async function GlossaryPage() {
           // display the terms
           <div className="py-6">
             <ul style={{ listStyleType: "none", padding: 0 }}>
-              {glossary.items.map((item) => (
-                // add a id to each term; use item.uuid, but could use item.id.replace(/[^a-zA-Z0-9-_:.]/g, '_')
-                // items could have 'seeAlso' property, which could be used to link to other terms
-                <li
+                {glossary.items
+                .sort((a, b) => a.term.localeCompare(b.term)) // Sort items by term
+                .map((item) => (
+                  <li
                   key={item.uuid}
                   style={{ marginBottom: "20px" }}
                   id={item.uuid}
-                >
+                  >
                   <strong>{item.term}</strong>
                   {item.acronym && (
                     <span style={{ marginLeft: "10px" }}>
-                      <em>({item.acronym})</em>
+                    <em>({item.acronym})</em>
                     </span>
                   )}
                   <p>{item.definition}</p>
                   <div>
                     {item.sourceUrl && (
-                      <Link
-                        href={item.sourceUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {item.sourceUrl}
-                      </Link>
+                    <Link
+                      href={item.sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {item.sourceUrl}
+                    </Link>
                     )}
                   </div>
-                </li>
-              ))}
+                  </li>
+                ))}
             </ul>
           </div>
         )}

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -3,6 +3,7 @@ import Header from "@/components/header/header";
 import { fetchGlossaries } from "@/hooks/use-glossaries";
 import { fetchGlossary } from "@/hooks/use-glossary";
 import { IGlossaries, IGlossary } from "@/types/entities/glossary.interface";
+import Link from "next/link";
 import React from "react";
 
 export default async function GlossaryPage() {
@@ -38,14 +39,27 @@ export default async function GlossaryPage() {
           <div className="py-6">
             <ul style={{ listStyleType: "none", padding: 0 }}>
               {glossary.items.map((item) => (
-                // add a id to each term; could use item.term.replace(/[^a-zA-Z0-9-_:.]/g, '_')
+                // add a id to each term; use item.uuid, but could use item.id.replace(/[^a-zA-Z0-9-_:.]/g, '_')
+                // items could have 'seeAlso' property, which could be used to link to other terms
                 <li
                   key={item.uuid}
                   style={{ marginBottom: "20px" }}
                   id={item.uuid}
                 >
                   <strong>{item.term}</strong>
+                  {item.acronym && (
+                    <span style={{ marginLeft: "10px" }}>
+                      <em>({item.acronym})</em>
+                    </span>
+                  )}
                   <p>{item.definition}</p>
+                  <div>
+                  {item.sourceUrl && (
+                  <Link href={item.sourceUrl} target="_blank" rel="noopener noreferrer">
+                    {item.sourceUrl}
+                  </Link>
+                  )}
+                  </div>
                 </li>
               ))}
             </ul>

--- a/client-fair-impact/app/glossary/page.tsx
+++ b/client-fair-impact/app/glossary/page.tsx
@@ -54,11 +54,15 @@ export default async function GlossaryPage() {
                   )}
                   <p>{item.definition}</p>
                   <div>
-                  {item.sourceUrl && (
-                  <Link href={item.sourceUrl} target="_blank" rel="noopener noreferrer">
-                    {item.sourceUrl}
-                  </Link>
-                  )}
+                    {item.sourceUrl && (
+                      <Link
+                        href={item.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {item.sourceUrl}
+                      </Link>
+                    )}
                   </div>
                 </li>
               ))}

--- a/client-fair-impact/hooks/fetch-glossaries.tsx
+++ b/client-fair-impact/hooks/fetch-glossaries.tsx
@@ -1,0 +1,13 @@
+import { IGlossaries } from "@/types/entities/glossary.interface";
+
+export const fetchGlossaries = async (): Promise<
+IGlossaries[]
+> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_HOST}/glossaries`,
+  );
+  if (!response.ok) {
+    throw new Error("Failed to retrieve glossaries");
+  }
+  return response.json();
+};

--- a/client-fair-impact/hooks/use-glossaries.tsx
+++ b/client-fair-impact/hooks/use-glossaries.tsx
@@ -1,17 +1,18 @@
 import { IGlossaries } from "@/types/entities/glossary.interface";
 import { useQuery } from "@tanstack/react-query";
+import { fetchGlossaries } from "@/hooks/fetch-glossaries";
 
-export const fetchGlossaries = async (): Promise<
-IGlossaries[]
-> => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_HOST}/glossaries`,
-  );
-  if (!response.ok) {
-    throw new Error("Failed to retrieve glossaries");
-  }
-  return response.json();
-};
+// export const fetchGlossaries = async (): Promise<
+// IGlossaries[]
+// > => {
+//   const response = await fetch(
+//     `${process.env.NEXT_PUBLIC_API_HOST}/glossaries`,
+//   );
+//   if (!response.ok) {
+//     throw new Error("Failed to retrieve glossaries");
+//   }
+//   return response.json();
+// };
 
 export default function useGlossaries() {
   return useQuery<IGlossaries[]>({

--- a/client-fair-impact/hooks/use-glossary-by-language-and-dot copy.tsx
+++ b/client-fair-impact/hooks/use-glossary-by-language-and-dot copy.tsx
@@ -1,0 +1,44 @@
+import { IGlossary } from "@/types/entities/glossary.interface";
+import { useQuery } from "@tanstack/react-query";
+
+export const fetchGlossaryByLanguageAndDOT = async (
+  languageCode: string,
+  digitalObjectTypeCode: string,
+): Promise<IGlossary> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_HOST}/glossaries/language/${languageCode}/dot/${digitalObjectTypeCode}`,
+  );
+
+  if (response.status === 404) {
+    throw new Error("Glossary not found");
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to retrieve glossary");
+  }
+  return response.json();
+};
+
+export default function useGlossaryByLanguageAndDOT(
+  languageCode: string,
+  digitalObjectTypeCode: string,
+) {
+  return useQuery<IGlossary>({
+    queryKey: ["glossary", languageCode, digitalObjectTypeCode],
+    queryFn: () =>
+      fetchGlossaryByLanguageAndDOT(
+        languageCode,
+        digitalObjectTypeCode,
+      ),
+    retry(failureCount, error) {
+      if (
+        error instanceof Error &&
+        error.message !== "Glossary not found"
+      ) {
+        return failureCount <= 3;
+      }
+      return false;
+    },
+    refetchOnWindowFocus: false,
+  });
+}

--- a/client-fair-impact/hooks/use-glossary.tsx
+++ b/client-fair-impact/hooks/use-glossary.tsx
@@ -13,9 +13,10 @@ export const fetchGlossary = async (
   return response.json();
 };
 
-export default function useGlossary(uuid: string) {
+export default function useGlossary(uuid: string, dependencyEnabled?: boolean) {
   return useQuery<IGlossary>({
     queryKey: ["glossary", uuid],
     queryFn: () => fetchGlossary(uuid),
+    enabled: dependencyEnabled
   });
 }

--- a/client-fair-impact/types/entities/glossary.interface.ts
+++ b/client-fair-impact/types/entities/glossary.interface.ts
@@ -7,6 +7,16 @@ export interface IGlossary {
 
     title: string;
     items: IGlossaryItem[];
+
+    digitalObjectType: {
+      uuid: string;
+      label: string;
+      code: string;
+    };
+    language: {
+      code: string;
+      englishLabel: string;
+    };
   }
 
   export interface IGlossaryItem {

--- a/client-fair-impact/types/entities/glossary.interface.ts
+++ b/client-fair-impact/types/entities/glossary.interface.ts
@@ -11,9 +11,11 @@ export interface IGlossary {
 
   export interface IGlossaryItem {
     uuid: string;
-    
+    id: string;
     term: string;
     definition: string;
+    sourceUrl: string | null;
+    acronym: string | null;
   }
 
   export type IGlossaries = Omit<IGlossary, "items">;

--- a/client-fair-impact/types/entities/glossary.interface.ts
+++ b/client-fair-impact/types/entities/glossary.interface.ts
@@ -1,3 +1,5 @@
+import { IDigitalObjectType } from "./digital-object-type.interface";
+
 export interface IGlossary {
     uuid: string;
 
@@ -8,16 +10,15 @@ export interface IGlossary {
     title: string;
     items: IGlossaryItem[];
 
-    digitalObjectType: {
-      uuid: string;
-      label: string;
-      code: string;
-    };
-    language: {
-      code: string;
-      englishLabel: string;
-    };
+    digitalObjectType: IDigitalObjectType;
+    language: ILanguage;
   }
+
+  // Need to specify the type of the language here
+  export interface ILanguage {
+    code: string;
+    englishLabel: string;
+  };
 
   export interface IGlossaryItem {
     uuid: string;


### PR DESCRIPTION
Get the Glossary working, but no edit or delete yet
Jira issue: https://drivenbydata.atlassian.net/browse/FR-2

Related PR's
https://github.com/DANS-KNAW/fair-aware/pull/18
https://github.com/DANS-KNAW/fair-aware/pull/20

1. Added glossary to the API

Examples

```
curl http://localhost:3001/glossaries | jq
curl http://localhost:3001/glossaries/989d7c32-5896-4b0a-8aab-21812f89e7c3 | jq
curl http://localhost:3001/glossaries/language/en/dot/DATA | jq
```

2. Add pages for CMS and Glossary page via menu

2.1 Menu
![glossary-menu-creenshot from 2025-04-01 18-27-45](https://github.com/user-attachments/assets/71af0ef8-88db-48f9-9eba-91c27dfb1665)

2.2 Glossaries
![cms-glossaries-Screenshot from 2025-04-01 18-28-26](https://github.com/user-attachments/assets/f4b53aa5-7466-4cb5-a078-18f8605cff31)

2.3 Glossary (details)
![cms-glossary-Screenshot from 2025-04-01 18-29-05](https://github.com/user-attachments/assets/5dfec20d-cae4-4857-8fd0-928a66212dc0)
