### PR TITLE
Customizable PrivacyPolicyLink as a setting

### DIFF
--- a/client-fair-impact/components/footer/footer.tsx
+++ b/client-fair-impact/components/footer/footer.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import Link from "next/link";
 import FooterLink from "./footer-link";
 import ImageLink from "./image-link";
 import { NavigationItem } from "@/types/navigation-item";
 import { fetchSetting } from "@/hooks/use-setting";
+import { useEffect, useState } from "react";
 
 const getPrivacyPolicyLink = async () => {
   try {
@@ -39,30 +42,40 @@ const getPrivacyPolicyLink = async () => {
     return ""; // sort of option None
   }
 };
-const privacyPolicyLink = await getPrivacyPolicyLink();
-
-const navigation: Record<string, NavigationItem[]> = {
-  site: [
-    { label: "About", href: "about" },
-    ...(privacyPolicyLink
-      ? [
-          {
-            label: "Privacy",
-            href: privacyPolicyLink,
-          },
-        ]
-      : []),
-  ],
-  resources: [
-    { label: "Documentation", href: "#" },
-    { label: "Source Code", href: "https://github.com/DANS-KNAW/fair-aware" },
-  ],
-};
 
 /**
  * Default footer component.
  */
 export default function Footer() {
+  const [privacyPolicyLink, setPrivacyPolicyLink] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const fetchPrivacyPolicyLink = async () => {
+      const link = await getPrivacyPolicyLink();
+      setPrivacyPolicyLink(link);
+    };
+
+    fetchPrivacyPolicyLink();
+  }, []);
+  const navigation: Record<string, NavigationItem[]> = {
+    site: [
+      { label: "About", href: "about" },
+      ...(privacyPolicyLink
+        ? [
+            {
+              label: "Privacy",
+              href: privacyPolicyLink,
+            },
+          ]
+        : []),
+    ],
+    resources: [
+      { label: "Documentation", href: "#" },
+      { label: "Source Code", href: "https://github.com/DANS-KNAW/fair-aware" },
+    ],
+  };
   return (
     <footer aria-labelledby="footer-heading" className="bg-white">
       <h2 id="footer-heading" className="sr-only">

--- a/client-fair-impact/components/footer/footer.tsx
+++ b/client-fair-impact/components/footer/footer.tsx
@@ -2,14 +2,56 @@ import Link from "next/link";
 import FooterLink from "./footer-link";
 import ImageLink from "./image-link";
 import { NavigationItem } from "@/types/navigation-item";
+import { fetchSetting } from "@/hooks/use-setting";
+
+const getPrivacyPolicyLink = async () => {
+  try {
+    const setting = await fetchSetting("PrivacyPolicyLink");
+
+    console.log("Privacy Policy Link:", JSON.stringify(setting, null, 2));
+
+    const value = setting.value.trim();
+    // check if value is a proper URL
+    // would prefer it this comes from a library...
+    const urlPattern = new RegExp(
+      "^(https?:\\/\\/)?" + // protocol
+        "((([a-z\\d]([a-z\\d-]*[a-z\\d])?)\\.)+[a-z]{2,}|" + // domain name
+        "localhost|" + // localhost
+        "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" + // IP address
+        "\\[?[a-fA-F0-9]*:[a-fA-F0-9:]+\\])" + // IPv6
+        "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // port and path
+        "(\\?[;&a-z\\d%_.~+=-]*)?" + // query string
+        "(\\#[-a-z\\d_]*)?$", // fragment locator
+      "i",
+    );
+    if (value && !urlPattern.test(value)) {
+      console.error("Invalid URL format for Privacy Policy Link:", value);
+      //return "https://default-privacy-policy-link.com"; // the default link
+      return ""; // sort of option None
+    }
+    // Note that we don't check if the URL resolves!
+
+    return value;
+    // default was "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/privacy-statement"
+  } catch (error) {
+    console.error("Failed to fetch Privacy Policy Link:", error);
+    //return "https://default-privacy-policy-link.com"; // the default link
+    return ""; // sort of option None
+  }
+};
+const privacyPolicyLink = await getPrivacyPolicyLink();
 
 const navigation: Record<string, NavigationItem[]> = {
   site: [
     { label: "About", href: "about" },
-    {
-      label: "Privacy",
-      href: "https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/privacy-statement",
-    },
+    ...(privacyPolicyLink
+      ? [
+          {
+            label: "Privacy",
+            href: privacyPolicyLink,
+          },
+        ]
+      : []),
   ],
   resources: [
     { label: "Documentation", href: "#" },

--- a/client-fair-impact/hooks/use-setting.tsx
+++ b/client-fair-impact/hooks/use-setting.tsx
@@ -11,6 +11,15 @@ export const fetchSetting = async (
       `${process.env.NEXT_PUBLIC_API_HOST}/settings/${id}`,
     );
     if (!response.ok) {
+      if (response.status === 404) {
+        console.warn(`Setting ${id} not found`);
+        // Return a default value for a non-existent setting, these are supposed to be optional
+        return {
+          id: `${id}`,
+          value: "",
+        };
+      }
+      console.error(`Error fetching setting ${id}: ${response.statusText}`);
       throw new Error(`Failed to retrieve setting: ${id}`);
     }
 

--- a/client-fair-impact/hooks/use-setting.tsx
+++ b/client-fair-impact/hooks/use-setting.tsx
@@ -1,0 +1,25 @@
+import { ISetting } from "@/types/entities/setting.interface";
+import { useQuery } from "@tanstack/react-query";
+
+export const fetchSetting = async (
+    id: string,
+  ): Promise<ISetting> => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_HOST}/settings/${id}`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to retrieve setting : ${id}`);
+    }
+
+    // TODO: possibly handle specific settings here, with validation and defaults
+
+    return response.json();
+  };
+  
+  export default function useGlossary(id: string, dependencyEnabled?: boolean) {
+    return useQuery<ISetting>({
+      queryKey: ["setting", id],
+      queryFn: () => fetchSetting(id),
+      enabled: dependencyEnabled
+    });
+  }

--- a/client-fair-impact/hooks/use-setting.tsx
+++ b/client-fair-impact/hooks/use-setting.tsx
@@ -4,11 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 export const fetchSetting = async (
     id: string,
   ): Promise<ISetting> => {
+    console.log(`fetchSetting on: ${process.env.NEXT_PUBLIC_API_HOST}/settings/${id}`);
+    
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_API_HOST}/settings/${id}`,
     );
     if (!response.ok) {
-      throw new Error(`Failed to retrieve setting : ${id}`);
+      throw new Error(`Failed to retrieve setting: ${id}`);
     }
 
     // TODO: possibly handle specific settings here, with validation and defaults
@@ -16,7 +18,7 @@ export const fetchSetting = async (
     return response.json();
   };
   
-  export default function useGlossary(id: string, dependencyEnabled?: boolean) {
+  export default function useSetting(id: string, dependencyEnabled?: boolean) {
     return useQuery<ISetting>({
       queryKey: ["setting", id],
       queryFn: () => fetchSetting(id),

--- a/client-fair-impact/types/entities/setting.interface.ts
+++ b/client-fair-impact/types/entities/setting.interface.ts
@@ -1,0 +1,6 @@
+
+export interface ISetting {
+    id: string;
+    value: string;
+}
+    


### PR DESCRIPTION
Jira issue: https://drivenbydata.atlassian.net/browse/FR-10

Testing: 
The policy link should only be shown (on the footer) if it is set and a valid URL. 
Note that the page and its data seems to be rather persistent, so after a change you might have to reload and or even close the page and open it again.


Create the setting:
```
curl -X POST -H "Content-Type: application/json" -d '{"id":"PrivacyPolicyLink","value":"https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/privacy-statement"}'  "http://localhost:3001/settings"
```
The link should be shown and let you navigate tho that DANS page.

Set a wrong link: 
```
curl -X POST -H "Content-Type: application/json" -d '{"id":"PrivacyPolicyLink","value":"something"}'  "http://localhost:3001/settings"
```
No link is shown. 

Remove the link:
```
curl -X DELETE "http://localhost:3001/settings/PrivacyPolicyLink"
```
No link is shown. 

Add the link again:  
```
curl -X POST -H "Content-Type: application/json" -d '{"id":"PrivacyPolicyLink","value":"https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/privacy-statement"}'  "http://localhost:3001/settings"
```

Check the API:
```
curl "http://localhost:3001/settings" | jq
```
Should show the setting. 
