### PR TITLE
FR-40 create default glossary on dot creation

### DIFF
--- a/api-fair-impact/src/digital-object-types/digital-object-types.module.ts
+++ b/api-fair-impact/src/digital-object-types/digital-object-types.module.ts
@@ -5,10 +5,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DigitalObjectType } from './entities/digital-object-type.entity';
 import { DigitalObjectTypeSchemasModule } from 'src/digital-object-type-schemas/digital-object-type-schemas.module';
 import { GlossariesModule } from 'src/glossaries/glossaries.module';
+import { LanguagesModule } from 'src/languages/languages.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([DigitalObjectType]),
+    LanguagesModule,
     forwardRef(() => DigitalObjectTypeSchemasModule),
     forwardRef(() => GlossariesModule),
   ],

--- a/api-fair-impact/src/digital-object-types/digital-object-types.service.ts
+++ b/api-fair-impact/src/digital-object-types/digital-object-types.service.ts
@@ -13,6 +13,7 @@ import { Repository } from 'typeorm';
 import { DigitalObjectType } from './entities/digital-object-type.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DigitalObjectTypeSchemasService } from 'src/digital-object-type-schemas/digital-object-type-schemas.service';
+import { GlossariesService } from 'src/glossaries/glossaries.service';
 
 @Injectable()
 export class DigitalObjectTypesService {
@@ -25,6 +26,8 @@ export class DigitalObjectTypesService {
     private readonly digitalObjectTypesRepository: Repository<DigitalObjectType>,
     @Inject(forwardRef(() => DigitalObjectTypeSchemasService))
     private readonly digitalObjectTypeSchemasService: DigitalObjectTypeSchemasService,
+    @Inject(forwardRef(() => GlossariesService))
+    private readonly glossariesService: GlossariesService,
   ) {}
 
   /**
@@ -54,6 +57,14 @@ export class DigitalObjectTypesService {
       // Create a default schema for the DOT
       await this.digitalObjectTypeSchemasService.create({
         digitalObjectTypeUUID: digitalObjectType.uuid,
+      });
+
+      // Create a default glossary for the DOT
+      await this.glossariesService.create({
+        digitalObjectTypeCode: digitalObjectType.code,
+        title: 'Glossary', // Default title
+        languageCode: 'en', // default language, a language is required, should be all active ones?
+        items: []
       });
 
       return digitalObjectType;


### PR DESCRIPTION
When creating a DOT, also a default (empty, with no items) Glossary will be created. It has the title 'Glossary' and the language will be the active language (English by default now). With multple active languages, multiple glossaries will be created, just like with the DOTS and CLM. 
Note that there is no way to change the glossary (add items) using the UI yet. 

Jira issue: https://drivenbydata.atlassian.net/browse/FR-40

