### PR TITLE
FR-41 add download and upload to glossary page

### DIFF
--- a/api-fair-impact/src/glossaries/dto/update-glossary.dto.ts
+++ b/api-fair-impact/src/glossaries/dto/update-glossary.dto.ts
@@ -1,0 +1,7 @@
+import { PartialType, PickType } from "@nestjs/mapped-types";
+import { Glossary } from "../entities/glossary.entity";
+
+
+export class UpdateGlossaryDto extends PartialType(
+  PickType(Glossary, ['title', 'items'] as const),
+) {}

--- a/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
+++ b/api-fair-impact/src/glossaries/entities/glossary-item.entity.ts
@@ -10,6 +10,7 @@ import {
   Column,
   Entity,
   ManyToOne,
+  PrimaryColumn,
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm';

--- a/api-fair-impact/src/glossaries/glossaries.controller.ts
+++ b/api-fair-impact/src/glossaries/glossaries.controller.ts
@@ -5,11 +5,13 @@ import {
   Get,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
 } from '@nestjs/common';
 import { GlossariesService } from './glossaries.service';
 import { CreateGlossaryDto } from './dto/create-glossery.dto';
 import { ParseISO639Pipe } from 'src/pipes/iso-639.pipe';
+import { UpdateGlossaryDto } from './dto/update-glossary.dto';
 
 @Controller('glossaries')
 export class GlossariesController {
@@ -31,6 +33,14 @@ export class GlossariesController {
     @Param('dot') dot: string,
   ) {
     return this.glossariesService.findByLanguageAndDot(language, dot);
+  }
+
+  @Patch(':uuid')
+  update(
+    @Param('uuid', new ParseUUIDPipe()) uuid: string,
+    @Body() updateGlossaryDto: UpdateGlossaryDto,
+  ) {
+    return this.glossariesService.update(uuid, updateGlossaryDto);
   }
 
   @Delete('language/:language/dot/:dot')

--- a/api-fair-impact/src/glossaries/glossaries.service.ts
+++ b/api-fair-impact/src/glossaries/glossaries.service.ts
@@ -10,6 +10,7 @@ import { Repository } from 'typeorm';
 
 import { Glossary } from './entities/glossary.entity';
 import { CreateGlossaryDto } from './dto/create-glossery.dto';
+import { UpdateGlossaryDto } from './dto/update-glossary.dto';
 
 @Injectable()
 export class GlossariesService {
@@ -42,9 +43,9 @@ export class GlossariesService {
         `Digital Object Type with code ${digitalObjectTypeCode} not found!`,
       );
     }
-    this.logger.debug('Rest: ' + JSON.stringify(rest, null, 2));
+    //this.logger.debug('Rest: ' + JSON.stringify(rest, null, 2));
 
-    this.logger.debug('Items: ' + JSON.stringify(items, null, 2));
+    //this.logger.debug('Items: ' + JSON.stringify(items, null, 2));
 
     const glossary = this.glossaryRepository.create({
       ...rest,
@@ -177,6 +178,28 @@ export class GlossariesService {
     }
   }
 
+  async update(
+    uuid: string,
+    updateGlossaryDto: UpdateGlossaryDto,
+  ): Promise<Glossary> {
+    try {
+      let glossary = await this.findOne(uuid);
+
+      const updatedGlossary = this.glossaryRepository.create({
+        ...glossary,
+        ...updateGlossaryDto,
+      });
+
+      return await this.glossaryRepository.save(updatedGlossary);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(error);
+      throw new InternalServerErrorException('Failed to update Glossary!');
+    }
+  }
+  
   async removeByLanguageAndDot(
     language: string,
     digitalObjectTypeCode: string,

--- a/client-fair-impact/app/cms/digital-object-types/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/digital-object-types/[uuid]/client.tsx
@@ -49,37 +49,37 @@ export default function ClientPage({ uuid }: { uuid: string }) {
     <>
       <div className="sticky top-0 z-10 -mt-14 border-b border-gray-300 bg-white pt-14 pb-8">
         <Breadcrumbs />
-
-        <h1 className="flex flex-col items-center justify-between sm:flex-row">
-          Digital Object Type
-        </h1>
-        <p className="text-base text-gray-600">
-          Here you can view and edit the details of a Digital Object Type.
-        </p>
-
-        <div className="flex space-x-2">
-          <button
-            type="button"
-            onClick={() => {
-              handleDelete();
-            }}
-            className="flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
-          >
-            <span className="mr-2">Delete</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              className="size-4"
+        <div className="flex flex-col items-center justify-between sm:flex-row">
+          <div>
+            <h1>Digital Object Type</h1>
+            <p className="text-base text-gray-600">
+              Here you can view and edit the details of a Digital Object Type.
+            </p>
+          </div>
+          <div className="flex space-x-2">
+            <button
+              type="button"
+              onClick={() => {
+                handleDelete();
+              }}
+              className="flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
             >
-              <path
-                fillRule="evenodd"
-                d="M9 3a3 3 0 0 1 6 0h5.25a.75.75 0 0 1 0 1.5h-.801l-.916 14.662A3.75 3.75 0 0 1 14.792 22H9.208a3.75 3.75 0 0 1-3.741-3.838L4.55 4.5H3.75a.75.75 0 0 1 0-1.5H9Zm1.5 0a1.5 1.5 0 0 1 3 0h-3ZM8.05 4.5l.9 14.4a2.25 2.25 0 0 0 2.258 2.1h5.584a2.25 2.25 0 0 0 2.258-2.1l.9-14.4H8.05ZM10 9a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5A.75.75 0 0 1 10 9Zm4 .75a.75.75 0 0 0-1.5 0v7.5a.75.75 0 0 0 1.5 0v-7.5Z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
+              <span className="mr-2">Delete</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+                className="size-4"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9 3a3 3 0 0 1 6 0h5.25a.75.75 0 0 1 0 1.5h-.801l-.916 14.662A3.75 3.75 0 0 1 14.792 22H9.208a3.75 3.75 0 0 1-3.741-3.838L4.55 4.5H3.75a.75.75 0 0 1 0-1.5H9Zm1.5 0a1.5 1.5 0 0 1 3 0h-3ZM8.05 4.5l.9 14.4a2.25 2.25 0 0 0 2.258 2.1h5.584a2.25 2.25 0 0 0 2.258-2.1l.9-14.4H8.05ZM10 9a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5A.75.75 0 0 1 10 9Zm4 .75a.75.75 0 0 0-1.5 0v7.5a.75.75 0 0 0 1.5 0v-7.5Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
       <div className="mt-12 border-t border-gray-900/10">

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -61,6 +61,34 @@ export default function ClientPage({ uuid }: { uuid: string }) {
           <button
             type="button"
             onClick={() => {
+              const blob = new Blob([JSON.stringify(data, null, 2)], {
+                type: "application/json",
+              });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = `glossary-${uuid}.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            className="flex cursor-pointer items-center rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
+          >
+            <span className="mr-2">Download</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+              className="size-4"
+            >
+              <path d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 0 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5Z" />
+              <path d="M3.5 9.75a.75.75 0 0 1 .75.75v2.25c0 .69.56 1.25 1.25 1.25h4.5c.69 0 1.25-.56 1.25-1.25V10.5a.75.75 0 0 1 1.5 0v2.25A2.75 2.75 0 0 1 10 15.5H5.75A2.75 2.75 0 0 1 3 12.75V10.5a.75.75 0 0 1 .75-.75Z" />
+            </svg>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
               handleDelete();
             }}
             className="flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -81,100 +81,98 @@ export default function ClientPage({ uuid }: { uuid: string }) {
             <h1 className="mb-2 text-2xl font-bold text-gray-800">Glossary</h1>
             <p className="text-base text-gray-600">This is a glossary.</p>
           </div>
-        </div>
-
-        <div className="flex space-x-2">
-          <button
-            type="button"
-            onClick={() => {
-              const blob = new Blob([JSON.stringify(data, null, 2)], {
-                type: "application/json",
-              });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement("a");
-              a.href = url;
-              a.download = `glossary-${uuid}.json`;
-              a.click();
-              URL.revokeObjectURL(url);
-            }}
-            className="flex cursor-pointer items-center rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
-          >
-            <span className="mr-2">Download</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              aria-hidden="true"
-              className="size-4"
+          <div className="flex space-x-2">
+            <button
+              type="button"
+              onClick={() => {
+                const blob = new Blob([JSON.stringify(data, null, 2)], {
+                  type: "application/json",
+                });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = `glossary-${uuid}.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+              }}
+              className="flex cursor-pointer items-center rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
             >
-              <path d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 0 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5Z" />
-              <path d="M3.5 9.75a.75.75 0 0 1 .75.75v2.25c0 .69.56 1.25 1.25 1.25h4.5c.69 0 1.25-.56 1.25-1.25V10.5a.75.75 0 0 1 1.5 0v2.25A2.75 2.75 0 0 1 10 15.5H5.75A2.75 2.75 0 0 1 3 12.75V10.5a.75.75 0 0 1 .75-.75Z" />
-            </svg>
-          </button>
-
-          <button
-            type="button"
-            onClick={() => {
-              const input = document.createElement("input");
-              input.type = "file";
-              input.accept = "application/json";
-              input.onchange = async (event) => {
-                const file = (event.target as HTMLInputElement).files?.[0];
-                if (file) {
-                  const text = await file.text();
-                  try {
-                    const parsedData = JSON.parse(text);
-                    console.log("Uploaded Glossary:", parsedData);
-                    mutation.mutate(parsedData);
-                  } catch (error) {
-                    console.error("Invalid JSON file: " + error);
-                    toasts.setToasts({
-                      type: "error",
-                      message: `Invalid JSON file: ${error instanceof Error ? error.message : "Unknown error"}`,
-                      subtext: "Please upload a valid JSON file.",
-                    });
+              <span className="mr-2">Download</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+                className="size-4"
+              >
+                <path d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 0 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5Z" />
+                <path d="M3.5 9.75a.75.75 0 0 1 .75.75v2.25c0 .69.56 1.25 1.25 1.25h4.5c.69 0 1.25-.56 1.25-1.25V10.5a.75.75 0 0 1 1.5 0v2.25A2.75 2.75 0 0 1 10 15.5H5.75A2.75 2.75 0 0 1 3 12.75V10.5a.75.75 0 0 1 .75-.75Z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const input = document.createElement("input");
+                input.type = "file";
+                input.accept = "application/json";
+                input.onchange = async (event) => {
+                  const file = (event.target as HTMLInputElement).files?.[0];
+                  if (file) {
+                    const text = await file.text();
+                    try {
+                      const parsedData = JSON.parse(text);
+                      console.log("Uploaded Glossary:", parsedData);
+                      mutation.mutate(parsedData);
+                    } catch (error) {
+                      console.error("Invalid JSON file: " + error);
+                      toasts.setToasts({
+                        type: "error",
+                        message: `Invalid JSON file: ${error instanceof Error ? error.message : "Unknown error"}`,
+                        subtext: "Please upload a valid JSON file.",
+                      });
+                    }
                   }
-                }
-              };
-              input.click();
-            }}
-            className="flex cursor-pointer items-center rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
-          >
-            <span className="mr-2">Upload</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              aria-hidden="true"
-              className="size-4"
+                };
+                input.click();
+              }}
+              className="flex cursor-pointer items-center rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
             >
-              <path d="M8 14.5a.75.75 0 0 1-.75-.75V7.06L5.03 9.28a.75.75 0 0 1-1.06-1.06l3.5-3.5a.75.75 0 0 1 1.06 0l3.5 3.5a.75.75 0 0 1-1.06 1.06L8.75 7.06v6.69a.75.75 0 0 1-.75.75Z" />
-              <path d="M3.5 6.25a.75.75 0 0 1 .75-.75h7.5a.75.75 0 0 1 0 1.5H4.25a.75.75 0 0 1-.75-.75Z" />
-            </svg>
-          </button>
+              <span className="mr-2">Upload</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+                className="size-4"
+              >
+                <path d="M8 14.5a.75.75 0 0 1-.75-.75V7.06L5.03 9.28a.75.75 0 0 1-1.06-1.06l3.5-3.5a.75.75 0 0 1 1.06 0l3.5 3.5a.75.75 0 0 1-1.06 1.06L8.75 7.06v6.69a.75.75 0 0 1-.75.75Z" />
+                <path d="M3.5 6.25a.75.75 0 0 1 .75-.75h7.5a.75.75 0 0 1 0 1.5H4.25a.75.75 0 0 1-.75-.75Z" />
+              </svg>
+            </button>
 
-          <button
-            type="button"
-            onClick={() => {
-              handleDelete();
-            }}
-            className="flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
-          >
-            <span className="mr-2">Delete</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              className="size-4"
+            <button
+              type="button"
+              onClick={() => {
+                handleDelete();
+              }}
+              className="flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
             >
-              <path
-                fillRule="evenodd"
-                d="M9 3a3 3 0 0 1 6 0h5.25a.75.75 0 0 1 0 1.5h-.801l-.916 14.662A3.75 3.75 0 0 1 14.792 22H9.208a3.75 3.75 0 0 1-3.741-3.838L4.55 4.5H3.75a.75.75 0 0 1 0-1.5H9Zm1.5 0a1.5 1.5 0 0 1 3 0h-3ZM8.05 4.5l.9 14.4a2.25 2.25 0 0 0 2.258 2.1h5.584a2.25 2.25 0 0 0 2.258-2.1l.9-14.4H8.05ZM10 9a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5A.75.75 0 0 1 10 9Zm4 .75a.75.75 0 0 0-1.5 0v7.5a.75.75 0 0 0 1.5 0v-7.5Z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
+              <span className="mr-2">Delete</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+                className="size-4"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9 3a3 3 0 0 1 6 0h5.25a.75.75 0 0 1 0 1.5h-.801l-.916 14.662A3.75 3.75 0 0 1 14.792 22H9.208a3.75 3.75 0 0 1-3.741-3.838L4.55 4.5H3.75a.75.75 0 0 1 0-1.5H9Zm1.5 0a1.5 1.5 0 0 1 3 0h-3ZM8.05 4.5l.9 14.4a2.25 2.25 0 0 0 2.258 2.1h5.584a2.25 2.25 0 0 0 2.258-2.1l.9-14.4H8.05ZM10 9a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5A.75.75 0 0 1 10 9Zm4 .75a.75.75 0 0 0-1.5 0v7.5a.75.75 0 0 0 1.5 0v-7.5Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 

--- a/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
+++ b/client-fair-impact/app/cms/glossaries/[uuid]/client.tsx
@@ -3,12 +3,38 @@
 import Breadcrumbs from "@/components/beardcrumbs";
 import { ToastContext } from "@/context/toast-context";
 import useGlossary from "@/hooks/use-glossary";
+import PatchGlossaryFetch from "@/lib/mutations/patch-glossary-fetch";
+import { getQueryClient } from "@/lib/query-provider";
+import { IGlossary } from "@/types/entities/glossary.interface";
+import { useMutation } from "@tanstack/react-query";
 import Link from "next/link";
 import { useContext } from "react";
 
 export default function ClientPage({ uuid }: { uuid: string }) {
   const { data, isLoading, isError } = useGlossary(uuid);
+  const queryClient = getQueryClient();
   const toasts = useContext(ToastContext);
+
+  const mutation = useMutation({
+    mutationFn: (newGlossary: IGlossary) => PatchGlossaryFetch(newGlossary),
+    onSuccess: () => {
+      toasts.setToasts({
+        type: "success",
+        message: "Successfully updated!",
+        subtext: "Glossary has been updated successfully.",
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["glossary", uuid],
+      });
+    },
+    onError: (error) => {
+      toasts.setToasts({
+        type: "error",
+        message: "Failed to update Glossary.",
+        subtext: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+      });
+    },
+  });
 
   const handleDelete = async () => {
     const confirmed = confirm(
@@ -83,6 +109,47 @@ export default function ClientPage({ uuid }: { uuid: string }) {
             >
               <path d="M8 1.5a.75.75 0 0 1 .75.75v6.69l2.22-2.22a.75.75 0 0 1 1.06 1.06l-3.5 3.5a.75.75 0 0 1-1.06 0l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.22 2.22V2.25A.75.75 0 0 1 8 1.5Z" />
               <path d="M3.5 9.75a.75.75 0 0 1 .75.75v2.25c0 .69.56 1.25 1.25 1.25h4.5c.69 0 1.25-.56 1.25-1.25V10.5a.75.75 0 0 1 1.5 0v2.25A2.75 2.75 0 0 1 10 15.5H5.75A2.75 2.75 0 0 1 3 12.75V10.5a.75.75 0 0 1 .75-.75Z" />
+            </svg>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              const input = document.createElement("input");
+              input.type = "file";
+              input.accept = "application/json";
+              input.onchange = async (event) => {
+                const file = (event.target as HTMLInputElement).files?.[0];
+                if (file) {
+                  const text = await file.text();
+                  try {
+                    const parsedData = JSON.parse(text);
+                    console.log("Uploaded Glossary:", parsedData);
+                    mutation.mutate(parsedData);
+                  } catch (error) {
+                    console.error("Invalid JSON file: " + error);
+                    toasts.setToasts({
+                      type: "error",
+                      message: `Invalid JSON file: ${error instanceof Error ? error.message : "Unknown error"}`,
+                      subtext: "Please upload a valid JSON file.",
+                    });
+                  }
+                }
+              };
+              input.click();
+            }}
+            className="flex cursor-pointer items-center rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
+          >
+            <span className="mr-2">Upload</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+              className="size-4"
+            >
+              <path d="M8 14.5a.75.75 0 0 1-.75-.75V7.06L5.03 9.28a.75.75 0 0 1-1.06-1.06l3.5-3.5a.75.75 0 0 1 1.06 0l3.5 3.5a.75.75 0 0 1-1.06 1.06L8.75 7.06v6.69a.75.75 0 0 1-.75.75Z" />
+              <path d="M3.5 6.25a.75.75 0 0 1 .75-.75h7.5a.75.75 0 0 1 0 1.5H4.25a.75.75 0 0 1-.75-.75Z" />
             </svg>
           </button>
 

--- a/client-fair-impact/lib/mutations/patch-glossary-fetch.ts
+++ b/client-fair-impact/lib/mutations/patch-glossary-fetch.ts
@@ -1,0 +1,22 @@
+import { IGlossary } from "@/types/entities/glossary.interface";
+
+export default async function PatchGlossaryFetch(
+  body: IGlossary,
+): Promise<IGlossary> {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_HOST}/glossaries/` + body.uuid,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to update glossary");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
Adds download and upload buttons  to the glossary page. 

Jira issue: https://drivenbydata.atlassian.net/browse/FR-41

Testing:
1. Download on glossary page
2. Edit the jJSON; change the title and change sometining on an item; term for instance. 
3. upload that changed file and check that changes are on the screen; glossary view.
 
